### PR TITLE
Vite entry/publicDir fix + Docker/Express deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "vite --config vite.config.js",
+    "build": "vite build --config vite.config.js",
     "start": "node server.mjs"
   },
   "dependencies": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,14 +3,14 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  root: '.',          // raíz del proyecto
+  root: '.',
   base: '/',
   plugins: [react()],
   publicDir: 'público',
   build: {
     outDir: 'dist',
     rollupOptions: {
-      input: path.resolve(__dirname, 'index.html')
-    }
-  }
+      input: path.resolve(process.cwd(), 'index.html'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- point Vite at root index.html and use `público` for static assets
- consolidate SPA entry to `src/main.tsx` and serve build via Express
- keep multi-stage Dockerfile for Railway deployment

## Testing
- `npm install`
- `npm run build`
- `PORT=4000 node server.mjs`
- `curl -I http://localhost:4000/`


------
https://chatgpt.com/codex/tasks/task_e_68c06e681b5c83209e07efe345248585