### PR TITLE
Add timeline chart and subtle palette

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { exportGridPng } from "./utils/capture"; // ya existe en tu repo
 import { exportExcel } from "./utils/exportExcel";
 import { ResonanceMeter } from "./components/ResonanceMeter";
+import { TimelineChart } from "./components/TimelineChart";
 import { SensitivityPanel } from "./components/SensitivityPanel";
 import { EventLog } from "./components/EventLog";
 import { cosineSim01, normalizeInPlace } from "./lib/resonance";
@@ -22,7 +23,8 @@ type Possibility = { id:string; features:number[]; energy:number };
 const N = 64;          // cantidad de posibilidades (Φ)
 const D = 3;           // dimensión de 𝓛(x) y features
 const TICK_MS = 120;   // paso temporal 𝓣
-const PALETTE = ["#7dd3fc","#a78bfa","#f0abfc","#f472b6","#60a5fa"];
+// paleta más sobria para un aspecto científico
+const PALETTE = ["#1e293b", "#334155", "#475569", "#64748b", "#94a3b8"];
 
 export default function App() {
   const [L, setL] = useState<number[]>([0.6,0.3,0.1]); // 𝓛(x)
@@ -85,6 +87,7 @@ export default function App() {
       <div className="grid md:grid-cols-3 gap-4">
         <div className="md:col-span-2 grid gap-3">
           <ResonanceMeter value={resonancia} />
+          <TimelineChart points={timeline} />
           <div className="grid grid-cols-4 gap-2" id="grid">
             {possibilities.map((p, idx) => {
               const r = cosineSim01(p.features, L);

--- a/src/components/TimelineChart.tsx
+++ b/src/components/TimelineChart.tsx
@@ -1,0 +1,36 @@
+// src/components/TimelineChart.tsx
+import React, { useEffect, useRef } from "react";
+
+export type TimelinePoint = { t: number; resonance: number };
+
+export function TimelineChart({ points }: { points: TimelinePoint[] }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = "#38bdf8"; // cyan-400
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+
+    const recent = points.slice(-100);
+    recent.forEach((p, i) => {
+      const x = (i / Math.max(recent.length - 1, 1)) * canvas.width;
+      const y = canvas.height - p.resonance * canvas.height;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }, [points]);
+
+  return (
+    <div className="border border-slate-700 rounded-xl p-3">
+      <strong className="text-sm">Resonancia reciente</strong>
+      <canvas ref={canvasRef} width={300} height={120} className="mt-2" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple canvas-based timeline chart to monitor resonance over time
- switch to a muted blue-gray palette for a more scientific look

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "xlsx" from src/utils/exportExcel.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c32164d658832084893a75974938b3