### PR TITLE
Add energy line plots for scientific UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,8 @@ function UniverseCell({ seed, running, onToggle, onResetSoft, onResetHard, mode 
   useEffect(() => {
     if (!running) return;
     let raf = 0;
-    let tt = 0;
+    // continue from existing timeline so pause/resume doesn't reset phases
+    let tt = t;
     const loop = () => {
       tt++;
       // oscillating metric for plot

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,7 +199,9 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
 
       if (onLatticeChange && tt - lastKernelUpdateRef.current > 200) {
         const delta = (res - 0.5) * 0.1;
-        const newKernel = kernel.map((v, i) => (i === 4 ? v + delta : v));
+        let newKernel = kernel.map((v) => v + delta * (v / ksum));
+        const newSum = newKernel.reduce((a, b) => a + b, 0) || 1;
+        newKernel = newKernel.map((v) => v * (ksum / newSum));
         onLatticeChange(newKernel);
         lastKernelUpdateRef.current = tt;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { KernelEditor } from "./components/KernelEditor";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
-type Possibility = { id: string; energy: number; symmetry: number; curvature: number; };
+type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
 function mulberry32(a: number) {
   return function () {
     let t = (a += 0x6d2b79f5);
@@ -23,7 +23,7 @@ function seededPossibilities(seed: number, n = 32): Possibility[] {
   const arr: Possibility[] = [];
   for (let i = 0; i < n; i++) {
     // start near an Ω-like vacuum: almost no energy, neutral symmetry and flat curvature
-    arr.push({ id: `p${i}`, energy: rnd() * 0.05, symmetry: 0.5, curvature: 0 });
+    arr.push({ id: `p${i}`, energy: rnd() * 0.05, symmetry: 0.5, curvature: 0, phase: rnd() * Math.PI * 2 });
   }
   return arr;
 }
@@ -106,7 +106,8 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
             -1,
             Math.min(1, p.curvature * 0.98 + 0.1 * Math.sin(tt * 0.04 + i) + 0.05 * (Math.random() - 0.5))
           );
-          return { ...p, energy, symmetry, curvature };
+          const phase = p.phase + 0.02 * speed + 0.01 * Math.sin(tt * 0.01 + i);
+          return { ...p, energy, symmetry, curvature, phase };
         });
         avg = next.reduce((a, p) => a + p.energy, 0) / next.length;
         res = next.reduce((a, p) => a + p.energy * p.symmetry, 0) / next.length;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
   const prev2Ref = useRef<number | null>(null);
   const lastPeakTickRef = useRef<number | null>(null);
   const lastKernelUpdateRef = useRef(0);
+  const prevResRef = useRef(0);
+  const resThreshold = 0.7;
 
   const reset = React.useCallback(() => {
     const snap: PhiSnapshot = {
@@ -168,9 +170,10 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
       res = Math.max(0, Math.min(1, res));
 
       let timeline = prev.timeline;
-      if (Math.random() < 0.06 * speed) {
+      if (res >= resThreshold && prevResRef.current < resThreshold) {
         timeline = [...timeline.slice(-63), { t: tt, score: avg }];
       }
+      prevResRef.current = res;
 
       const snap: PhiSnapshot = { t: tt, energy: avg, symmetry: avgSym, curvature: avgCurv, possibilities: nextPoss, timeline };
       snapshotRef.current = snap;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,9 +254,9 @@ export default function App(){
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 relative">
-      <header className="flex items-center justify-between mb-4">
-        <h1 className="text-xl sm:text-2xl font-bold">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
-        <div className="flex flex-wrap gap-2">
+      <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
+        <h1 className="text-xl sm:text-2xl font-bold text-center sm:text-left">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
+        <div className="flex flex-wrap justify-center sm:justify-end gap-2">
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={startAll}>Iniciar todo</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={pauseAll}>Pausar todo</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={resetAllSoft}>Reset 𝓣/R</button>
@@ -266,8 +266,8 @@ export default function App(){
         </div>
       </header>
 
-      <div className="flex gap-4">
-        <aside className="w-2/5 space-y-4">
+      <div className="flex flex-col lg:flex-row gap-4">
+        <aside className="space-y-4 w-full lg:w-2/5">
           <GlobalParamsPanel
             seedBase={baseSeed}
             setSeedBase={setBaseSeed}
@@ -280,9 +280,9 @@ export default function App(){
           />
           <KernelEditor kernel={kernel} setKernel={setKernel} />
         </aside>
-        <main className="w-3/5">
+        <main className="w-full lg:w-3/5">
           <div id="grid">
-            <div className="grid grid-cols-3 gap-4 mb-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
               {seeds.map((s, i) => (
                 <UniverseCell
                   key={"v"+i+"-"+s}
@@ -301,7 +301,7 @@ export default function App(){
                 />
               ))}
             </div>
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {seeds.map((s, i) => (
                 <UniverseCell
                   key={"p"+i+"-"+s}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,9 +124,9 @@ export default function App(){
   const exportExcel = () => {
     const rows: string[] = [];
     historiesRef.current.forEach((hist, i) => {
-      rows.push(`Grafica ${i}`);
+      rows.push(`Gráfica ${i + 1}`);
       rows.push("t,value");
-      hist.forEach((v, idx) => rows.push(`${idx},${v}`));
+      hist.forEach((v, idx) => rows.push(`${idx + 1},${v}`));
       rows.push("");
     });
     const csv = rows.join("\n");
@@ -164,7 +164,7 @@ export default function App(){
               onResetSoft={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? v : v))}
               onResetHard={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? Math.floor(Math.random()*100000) : v))}
               mode="visual"
-              label={`Cámara Φ-${i}`}
+              label={`Cámara Φ-${i + 1}`}
             />
           ))}
         </div>
@@ -178,7 +178,7 @@ export default function App(){
               onResetSoft={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? v : v))}
               onResetHard={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? Math.floor(Math.random()*100000) : v))}
               mode="plot"
-              label={`Gráfica ${i}`}
+              label={`Gráfica ${i + 1}`}
               onHistory={arr => { historiesRef.current[i] = arr; }}
             />
           ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { exportGridPng } from "./utils/capture";
 import { LinePlot } from "./components/LinePlot";
+import { PhiCanvas } from "./components/PhiCanvas";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; };
@@ -36,10 +37,14 @@ function UniverseCell({ seed, running, onToggle, onResetSoft, onResetHard, mode 
 }){
   const [poss, setPoss] = useState(seededPossibilities(seed, 36));
   const [history, setHistory] = useState<number[]>([]);
+  const [timeline, setTimeline] = useState<{t:number; score:number}[]>([]);
+  const [t, setT] = useState(0);
 
   useEffect(() => {
     setPoss(seededPossibilities(seed, 36));
     setHistory([]);
+    setTimeline([]);
+    setT(0);
     onHistory?.([]);
   }, [seed, onHistory]);
 
@@ -58,17 +63,27 @@ function UniverseCell({ seed, running, onToggle, onResetSoft, onResetHard, mode 
         onHistory?.(next);
         return next;
       });
+      if (Math.random() < 0.06) {
+        setTimeline(arr => [...arr.slice(-63), { t: tt, score: Math.random() }]);
+      }
+      setT(tt);
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, [running, poss]);
+  }, [running, poss, onHistory]);
 
   return (
     <div className="bg-slate-900/70 rounded-2xl p-3 capture-frame relative">
       {label && <div className="text-sm font-semibold mb-2">{label}</div>}
       {mode !== "plot" && (
-        <LinePlot data={history} className="h-48 bg-indigo-900" />
+        <PhiCanvas
+          possibilities={poss}
+          timeline={timeline}
+          t={t}
+          className="h-48"
+          paletteIndex={seed}
+        />
       )}
       {mode !== "visual" && (
         <div className={mode === "both" ? "mt-3" : ""}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,7 +155,17 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
       const avg = nextPoss.reduce((a, p) => a + p.energy, 0) / nextPoss.length;
       const avgSym = nextPoss.reduce((a, p) => a + p.symmetry, 0) / nextPoss.length;
       const avgCurv = nextPoss.reduce((a, p) => a + p.curvature, 0) / nextPoss.length;
-      const res = nextPoss.reduce((a, p) => a + p.energy * p.symmetry, 0) / nextPoss.length;
+      let res =
+        nextPoss.reduce(
+          (a, p) =>
+            a +
+            p.energy *
+              p.symmetry *
+              (1 - Math.abs(p.curvature)) *
+              (0.5 + 0.5 * Math.cos(tt * 0.02 + p.phase)),
+          0
+        ) / nextPoss.length;
+      res = Math.max(0, Math.min(1, res));
 
       let timeline = prev.timeline;
       if (Math.random() < 0.06 * speed) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,6 +153,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
           possibilities={poss}
           timeline={timeline}
           t={t}
+          speed={speed}
           className="h-48"
           paletteIndex={seed}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ function seededPossibilities(seed: number, n = 32): Possibility[] {
 }
 
 // ======= One universe cell with visual + plot =======
-function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, onResetSoft, onResetHard, mode = "both", label, onHistory, resetSignal }:{
+function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, onResetSoft, onResetHard, mode = "both", label, onHistory, resetSignal, onLatticeChange }:{
   seed: number;
   running: boolean;
   speed: number;
@@ -43,13 +43,14 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
   label?: string;
   onHistory?: (hist: number[]) => void;
   resetSignal: number;
+  onLatticeChange?: (k: number[]) => void;
 }){
   const [snapshot, setSnapshot] = useState<PhiSnapshot>(() => ({
     t: 0,
     energy: 0,
     symmetry: 0.5,
     curvature: 0,
-    possibilities: seededPossibilities(seed, grid),
+    possibilities: seededPossibilities(seed, grid * grid),
     timeline: [],
   }));
   const snapshotRef = useRef(snapshot);
@@ -59,6 +60,7 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
   const prev1Ref = useRef<number | null>(null);
   const prev2Ref = useRef<number | null>(null);
   const lastPeakTickRef = useRef<number | null>(null);
+  const lastKernelUpdateRef = useRef(0);
 
   const reset = React.useCallback(() => {
     const snap: PhiSnapshot = {
@@ -66,7 +68,7 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
       energy: 0,
       symmetry: 0.5,
       curvature: 0,
-      possibilities: seededPossibilities(seed, grid),
+      possibilities: seededPossibilities(seed, grid * grid),
       timeline: [],
     };
     snapshotRef.current = snap;
@@ -102,40 +104,58 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
       const cooling = Math.exp(-tt * 0.0005);
       const base = expansion * cooling;
 
-      const center = kernel[4] ?? 1;
       const ksum = kernel.reduce((a, b) => a + b, 0) || 1;
-      let energyFirst = 0;
-      const nextPoss = prev.possibilities.map((p, i) => {
-        const noise = 0.1 * speed * (Math.random() - 0.5);
-        const oscill = 0.15 * Math.sin(tt * 0.05 + i) * speed;
-        const energy = Math.min(
-          1,
-          Math.max(0, base * center + oscill + noise + balance * 0.5)
-        );
-        const symmetry = Math.min(
-          1,
-          Math.max(
-            0,
-            0.5 + 0.5 * Math.cos(tt * 0.03 + i) * base * (ksum / 9) +
-              balance * 0.5 + 0.1 * speed * (Math.random() - 0.5)
-          )
-        );
-        const curvature = Math.max(
-          -1,
-          Math.min(
+      const side = grid;
+      const prevPoss = prev.possibilities;
+      const nextPoss: Possibility[] = [];
+      for (let y = 0; y < side; y++) {
+        for (let x = 0; x < side; x++) {
+          const idx = y * side + x;
+          const p = prevPoss[idx];
+          let conv = 0;
+          let wsum = 0;
+          for (let dy = -1; dy <= 1; dy++) {
+            for (let dx = -1; dx <= 1; dx++) {
+              const w = kernel[(dy + 1) * 3 + (dx + 1)] ?? 0;
+              const nx = (x + dx + side) % side;
+              const ny = (y + dy + side) % side;
+              const nidx = ny * side + nx;
+              conv += w * prevPoss[nidx].energy;
+              wsum += w;
+            }
+          }
+          const convNorm = wsum ? conv / wsum : 0;
+          const noise = 0.1 * speed * (Math.random() - 0.5);
+          const oscill = 0.15 * Math.sin(tt * 0.05 + idx) * speed;
+          let energy = base * convNorm + oscill + noise + balance * 0.5;
+          energy = Math.min(1, Math.max(0, energy));
+          energy *= 1 - 0.01 * wsum; // fricción ontológica
+          const symmetry = Math.min(
             1,
-            p.curvature * 0.98 + 0.1 * Math.sin(tt * 0.04 + i) * speed +
-              (center - 1) * 0.1 + 0.05 * speed * (Math.random() - 0.5)
-          )
-        );
-        const phase = p.phase + 0.02 * speed + 0.01 * speed * Math.sin(tt * 0.01 + i);
-        return { ...p, energy, symmetry, curvature, phase };
-      });
+            Math.max(
+              0,
+              0.5 + 0.5 * Math.cos(tt * 0.03 + idx) * convNorm +
+                balance * 0.5 + 0.1 * speed * (Math.random() - 0.5)
+            )
+          );
+          const curvature = Math.max(
+            -1,
+            Math.min(
+              1,
+              p.curvature * 0.98 +
+                0.1 * Math.sin(tt * 0.04 + idx) * speed +
+                (convNorm - 1) * 0.1 +
+                0.05 * speed * (Math.random() - 0.5)
+            )
+          );
+          const phase = p.phase + 0.02 * speed + 0.01 * speed * Math.sin(tt * 0.01 + idx);
+          nextPoss[idx] = { ...p, energy, symmetry, curvature, phase };
+        }
+      }
       const avg = nextPoss.reduce((a, p) => a + p.energy, 0) / nextPoss.length;
       const avgSym = nextPoss.reduce((a, p) => a + p.symmetry, 0) / nextPoss.length;
       const avgCurv = nextPoss.reduce((a, p) => a + p.curvature, 0) / nextPoss.length;
       const res = nextPoss.reduce((a, p) => a + p.energy * p.symmetry, 0) / nextPoss.length;
-      energyFirst = nextPoss[0]?.energy ?? 0;
 
       let timeline = prev.timeline;
       if (Math.random() < 0.06 * speed) {
@@ -151,7 +171,7 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
         prev2Ref.current !== null &&
         prev1Ref.current !== null &&
         prev1Ref.current > prev2Ref.current &&
-        prev1Ref.current > energyFirst
+        prev1Ref.current > avg
       ) {
         if (lastPeakTickRef.current != null) {
           const periodTicks = tt - lastPeakTickRef.current;
@@ -162,7 +182,14 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
         lastPeakTickRef.current = tt;
       }
       prev2Ref.current = prev1Ref.current;
-      prev1Ref.current = energyFirst;
+      prev1Ref.current = avg;
+
+      if (onLatticeChange && tt - lastKernelUpdateRef.current > 200) {
+        const delta = (res - 0.5) * 0.1;
+        const newKernel = kernel.map((v, i) => (i === 4 ? v + delta : v));
+        onLatticeChange(newKernel);
+        lastKernelUpdateRef.current = tt;
+      }
 
       if (runningRef.current) {
         raf = requestAnimationFrame(loop);
@@ -298,6 +325,7 @@ export default function App(){
                   mode="visual"
                   label={`Cámara Φ-${i + 1}`}
                   resetSignal={resetSignals[i]}
+                  onLatticeChange={setKernel}
                 />
               ))}
             </div>
@@ -318,6 +346,7 @@ export default function App(){
                   label={`Gráfica ${i + 1}`}
                   onHistory={arr => { historiesRef.current[i] = arr; }}
                   resetSignal={resetSignals[i]}
+                  onLatticeChange={setKernel}
                 />
               ))}
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { LinePlot } from "./components/LinePlot";
 import { PhiCanvas } from "./components/PhiCanvas";
 import { GlobalParamsPanel } from "./components/GlobalParamsPanel";
 import { KernelEditor } from "./components/KernelEditor";
+import { ResonanceMeter } from "./components/ResonanceMeter";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; };
@@ -45,6 +46,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
   const [timeline, setTimeline] = useState<{t:number; score:number}[]>([]);
   const [t, setT] = useState(0);
   const [freqHz, setFreqHz] = useState(0);
+  const [resonance, setResonance] = useState(0);
   // keep a short rolling buffer to estimate frequency from energy oscillations
   const prev1Ref = useRef<number | null>(null);
   const prev2Ref = useRef<number | null>(null);
@@ -89,6 +91,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
       const base = expansion * cooling;
 
       let avg = 0;
+      let res = 0;
       setPoss(prev => {
         const next = prev.map((p, i) => {
           const noise = 0.1 * (Math.random() - 0.5);
@@ -105,8 +108,10 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
           return { ...p, energy, symmetry, curvature };
         });
         avg = next.reduce((a, p) => a + p.energy, 0) / next.length;
+        res = next.reduce((a, p) => a + p.energy * p.symmetry, 0) / next.length;
         return next;
       });
+      setResonance(res);
 
       // capture the average energy for the analytic graph (R)
       const WINDOW = 30;
@@ -166,6 +171,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
         <div className={mode === "both" ? "mt-3" : ""}>
           <LinePlot data={history} />
           <div className="text-xs mt-1">f ≈ {freqHz.toFixed(2)} Hz</div>
+          <div className="mt-2"><ResonanceMeter value={resonance} /></div>
         </div>
       )}
       {mode !== "visual" && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -185,7 +185,7 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
       )}
       {mode !== "visual" && (
         <div className={mode === "both" ? "mt-3" : ""}>
-          <LinePlot snapshot={snapshot} onHistory={onHistory} />
+          <LinePlot snapshot={snapshot} running={running} onHistory={onHistory} />
           <div className="text-xs mt-1">f ≈ {freqHz.toFixed(2)} Hz</div>
           <div className="mt-2"><ResonanceMeter value={resonance} /></div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,8 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
       setResonance(res);
 
       // capture the average energy for the analytic graph (R)
-      const WINDOW = 30;
+      // show a broader historical panorama of the energy signal
+      const WINDOW = 60;
       setHistory(arr => {
         const next = [...arr.slice(-(WINDOW - 1)), avg];
         onHistoryRef.current?.(next);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,11 @@
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AXIOM_LABELS, MICRO_LEGENDS } from "./axioms";
 import { exportGridPng } from "./utils/capture";
+import { LinePlot } from "./components/LinePlot";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; };
-type EventEpsilon = { t: number; collapsedId: string; score: number; };
-
-// ======= Color palettes (from BigBang1 feel + multiverso variants) =======
-const PALETTES: string[][] = [
-  ["#7dd3fc","#a78bfa","#f0abfc","#f472b6","#60a5fa"], // aurora cool
-  ["#fef08a","#fca5a5","#fdba74","#f97316","#fde68a"], // warm sunrise
-  ["#34d399","#22d3ee","#38bdf8","#a7f3d0","#f5d0fe"], // bio-neon
-  ["#ef4444","#f59e0b","#10b981","#3b82f6","#8b5cf6"], // bold spectrum
-];
-
 function mulberry32(a: number) {
   return function () {
     let t = (a += 0x6d2b79f5);
@@ -33,87 +24,30 @@ function seededPossibilities(seed: number, n = 32): Possibility[] {
   return arr;
 }
 
-// ======= The visual canvas (keeps BigBang2 layout but enhances style) =======
-function PhiCanvas({ possibilities, timeline, t, paletteIndex }:{ possibilities: Possibility[]; timeline: EventEpsilon[]; t: number; paletteIndex: number }) {
-  const ref = useRef<HTMLCanvasElement | null>(null);
-
-  useEffect(() => {
-    const cvs = ref.current!;
-    const ctx = cvs.getContext("2d")!;
-    const W = (cvs.width = cvs.clientWidth);
-    const H = (cvs.height = cvs.clientHeight);
-
-    // background gradient (BigBang1 feel)
-    const grad = ctx.createLinearGradient(0,0,W,H);
-    const pal = PALETTES[paletteIndex % PALETTES.length];
-    pal.forEach((c, i) => grad.addColorStop(i/(pal.length-1), c));
-    ctx.fillStyle = grad;
-    ctx.fillRect(0,0,W,H);
-
-    // particles (Φ possibilities) with resonance glow (multiverso feel)
-    for (let i = 0; i < possibilities.length; i++) {
-      const p = possibilities[i];
-      const x = ((i * 9973) % W) * 0.03 + (p.symmetry * W) % W;
-      const y = ((i * 7919) % H) * 0.04 + ((p.energy + 0.12 * Math.sin(t*0.03+i)) * H) % H;
-      const r = 2 + 3 * Math.abs(p.curvature);
-      const hue = Math.floor(360 * (p.energy * 0.6 + p.symmetry * 0.4));
-      ctx.beginPath();
-      ctx.fillStyle = `hsla(${hue}, 90%, 60%, 0.85)`;
-      ctx.shadowColor = `hsla(${hue}, 100%, 70%, 0.9)`;
-      ctx.shadowBlur = 12;
-      ctx.arc(x % W, y % H, r, 0, Math.PI * 2);
-      ctx.fill();
-    }
-
-    // timeline pulses (ε events)
-    ctx.shadowBlur = 0;
-    for (const e of timeline.slice(-8)) {
-      const phase = (t - e.t) * 0.05;
-      const alpha = Math.max(0, 0.6 - phase * 0.08);
-      if (alpha <= 0) continue;
-      ctx.strokeStyle = `rgba(255,255,255,${alpha})`;
-      ctx.lineWidth = 1 + 2 * (1 - alpha);
-      const cx = (e.score * 997) % W;
-      const cy = (e.score * 661) % H;
-      ctx.beginPath();
-      ctx.arc(cx, cy, 12 + phase*12, 0, Math.PI*2);
-      ctx.stroke();
-    }
-  }, [possibilities, timeline, t, paletteIndex]);
-
-  return <canvas ref={ref} className="w-full rounded-xl" style={{ height: 280 }} />;
-}
-
-// ======= One universe cell =======
-function UniverseCell({ seed, running, onToggle, onResetSoft, onResetHard, paletteIndex }:{
-  seed: number; running: boolean; onToggle: () => void; onResetSoft: () => void; onResetHard: () => void; paletteIndex: number;
+// ======= One universe cell with line plot =======
+function UniverseCell({ seed, running, onToggle, onResetSoft, onResetHard }:{
+  seed: number; running: boolean; onToggle: () => void; onResetSoft: () => void; onResetHard: () => void;
 }){
-  const [t, setT] = useState(0);
   const [poss, setPoss] = useState(seededPossibilities(seed, 36));
-  const [timeline, setTimeline] = useState<EventEpsilon[]>([]);
+  const [history, setHistory] = useState<number[]>([]);
 
-  useEffect(() => { setPoss(seededPossibilities(seed, 36)); setTimeline([]); setT(0); }, [seed]);
+  useEffect(() => { setPoss(seededPossibilities(seed, 36)); setHistory([]); }, [seed]);
 
   useEffect(() => {
     if (!running) return;
     let raf = 0;
     const loop = () => {
-      setT(prev => prev + 1);
-      // probabilistic event (ε) with resonance (ℜ) flavor
-      if (Math.random() < 0.06) {
-        const id = poss[Math.floor(Math.random()*poss.length)].id;
-        const score = Math.random();
-        setTimeline(arr => [...arr, { t: t, collapsedId: id, score }].slice(-64));
-      }
+      const avg = poss.reduce((a,p)=>a+p.energy,0)/poss.length;
+      setHistory(arr => [...arr.slice(-99), avg]);
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, [running, poss, t]);
+  }, [running, poss]);
 
   return (
     <div className="bg-slate-900/70 rounded-2xl p-3 capture-frame relative">
-      <PhiCanvas possibilities={poss} timeline={timeline} t={t} paletteIndex={paletteIndex} />
+      <LinePlot data={history} />
       <div className="mt-2 flex items-center gap-2 text-xs opacity-80">
         <button className={"px-2 py-1 rounded-md "+(running?"bg-slate-800":"bg-indigo-700") } onClick={onToggle}>{running? "Pausar 𝓣":"Iniciar 𝓣"}</button>
         <button className="px-2 py-1 rounded-md bg-slate-800" onClick={onResetSoft}>Reset 𝓣/R</button>
@@ -166,7 +100,6 @@ export default function App(){
   const total = rows*cols;
   const [seeds, setSeeds] = useState<number[]>(() => Array.from({length: total}, (_,i)=> 42 + i*7));
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: total}, ()=> true));
-  const [palette, setPalette] = useState(0);
 
   useEffect(()=>{
     // resize grid preserves first N seeds
@@ -181,7 +114,6 @@ export default function App(){
   const resetAllHard = () => setSeeds(prev => prev.map((_,i)=> Math.floor(Math.random()*100000)));
 
   const [showAxioms, setShowAxioms] = useState(false);
-  const [labelsMode, setLabelsMode] = useState<"min"|"full">("min");
 
   // keyboard shortcut A
   useEffect(()=>{
@@ -214,10 +146,7 @@ export default function App(){
         <select value={cols} onChange={e=>setCols(parseInt(e.target.value))} className="bg-slate-900 rounded-md px-2 py-1">
           {[1,2,3,4].map(n=><option key={n} value={n}>{n} cols</option>)}
         </select>
-        <span className="ml-4">Paleta:</span>
-        <select value={palette} onChange={e=>setPalette(parseInt(e.target.value))} className="bg-slate-900 rounded-md px-2 py-1">
-          {PALETTES.map((_,i)=><option key={i} value={i}>#{i+1}</option>)}
-        </select>
+        {/* Paleta eliminada para una interfaz más científica */}
       </div>
 
       <div id="grid" className="grid gap-4" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
@@ -229,7 +158,6 @@ export default function App(){
             onToggle={()=> setRunning(prev => prev.map((v,idx)=> idx===i ? !v : v))}
             onResetSoft={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? v : v))}
             onResetHard={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? Math.floor(Math.random()*100000) : v))}
-            paletteIndex={(palette + i) % PALETTES.length}
           />
         ))}
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,18 +103,18 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
       let energyFirst = 0;
       setPoss(prev => {
         const next = prev.map((p, i) => {
-          const noise = 0.1 * (Math.random() - 0.5);
-          const oscill = 0.15 * Math.sin(tt * 0.05 + i);
+          const noise = 0.1 * speed * (Math.random() - 0.5);
+          const oscill = 0.15 * Math.sin(tt * 0.05 + i) * speed;
           const energy = Math.min(1, Math.max(0, base + oscill + noise));
           const symmetry = Math.min(
             1,
-            Math.max(0, 0.5 + 0.5 * Math.cos(tt * 0.03 + i) * base + 0.1 * (Math.random() - 0.5))
+            Math.max(0, 0.5 + 0.5 * Math.cos(tt * 0.03 + i) * base + 0.1 * speed * (Math.random() - 0.5))
           );
           const curvature = Math.max(
             -1,
-            Math.min(1, p.curvature * 0.98 + 0.1 * Math.sin(tt * 0.04 + i) + 0.05 * (Math.random() - 0.5))
+            Math.min(1, p.curvature * 0.98 + 0.1 * Math.sin(tt * 0.04 + i) * speed + 0.05 * speed * (Math.random() - 0.5))
           );
-          const phase = p.phase + 0.02 * speed + 0.01 * Math.sin(tt * 0.01 + i);
+          const phase = p.phase + 0.02 * speed + 0.01 * speed * Math.sin(tt * 0.01 + i);
           return { ...p, energy, symmetry, curvature, phase };
         });
         avg = next.reduce((a, p) => a + p.energy, 0) / next.length;
@@ -152,7 +152,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
       prev1Ref.current = energyFirst;
 
       // ε events sampled from resonant energy peaks
-      if (Math.random() < 0.06) {
+      if (Math.random() < 0.06 * speed) {
         setTimeline(arr => [...arr.slice(-63), { t: tt, score: avg }]);
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,8 +130,10 @@ function UniverseCell({ seed, running, speed, grid, balance, kernel, onToggle, o
           const noise = 0.1 * speed * (Math.random() - 0.5);
           const oscill = 0.15 * Math.sin(tt * 0.05 + idx) * speed;
           let energy = base * convNorm + oscill + noise + balance * 0.5;
-          energy = Math.min(1, Math.max(0, energy));
-          energy *= 1 - 0.01 * wsum; // fricción ontológica
+          const clamped = Math.min(1, Math.max(0, energy));
+          const gradient = Math.abs(convNorm - p.energy);
+          const friction = 0.01 * wsum * (1 + prevResRef.current) * gradient;
+          energy = Math.max(0, Math.min(1, clamped * (1 - friction)));
           const symmetry = Math.min(
             1,
             Math.max(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,18 +48,23 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
   const prevRef = useRef(0);
   const trendRef = useRef(0);
   const lastPeakRef = useRef<number | null>(null);
+  const onHistoryRef = useRef(onHistory);
+
+  useEffect(() => {
+    onHistoryRef.current = onHistory;
+  }, [onHistory]);
 
   const reset = React.useCallback(() => {
     setPoss(seededPossibilities(seed, 36));
     setHistory([]);
     setTimeline([]);
     setT(0);
-    onHistory?.([]);
+    onHistoryRef.current?.([]);
     setFreqHz(0);
     prevRef.current = 0;
     trendRef.current = 0;
     lastPeakRef.current = null;
-  }, [seed, onHistory]);
+  }, [seed]);
 
   useEffect(() => {
     reset();
@@ -106,7 +111,7 @@ function UniverseCell({ seed, running, speed, onToggle, onResetSoft, onResetHard
       const WINDOW = 30;
       setHistory(arr => {
         const next = [...arr.slice(-(WINDOW - 1)), avg];
-        onHistory?.(next);
+        onHistoryRef.current?.(next);
         return next;
       });
 

--- a/src/components/GlobalParamsPanel.tsx
+++ b/src/components/GlobalParamsPanel.tsx
@@ -54,7 +54,7 @@ export function GlobalParamsPanel({
         <div className="text-xs mt-1">{speed.toFixed(1)}x</div>
       </label>
       <label className="block text-sm">
-        Balance Ω/ℂ
+        Balance Ω/Φ
         <input
           type="range"
           min={-1}

--- a/src/components/GlobalParamsPanel.tsx
+++ b/src/components/GlobalParamsPanel.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+export function GlobalParamsPanel({
+  seedBase,
+  setSeedBase,
+  speed,
+  setSpeed,
+  grid,
+  setGrid,
+  balance,
+  setBalance,
+}: {
+  seedBase: number;
+  setSeedBase: (v: number) => void;
+  speed: number;
+  setSpeed: (v: number) => void;
+  grid: number;
+  setGrid: (v: number) => void;
+  balance: number;
+  setBalance: (v: number) => void;
+}) {
+  return (
+    <div className="bg-slate-900/70 rounded-2xl p-4 space-y-4">
+      <h2 className="font-semibold">Parámetros globales</h2>
+      <label className="block text-sm">
+        Semilla base
+        <input
+          type="number"
+          className="mt-1 w-full rounded-md bg-slate-800 p-1"
+          value={seedBase}
+          onChange={(e) => setSeedBase(parseInt(e.target.value) || 0)}
+        />
+      </label>
+      <label className="block text-sm">
+        Grid
+        <input
+          type="number"
+          className="mt-1 w-full rounded-md bg-slate-800 p-1"
+          value={grid}
+          onChange={(e) => setGrid(parseInt(e.target.value) || 0)}
+        />
+      </label>
+      <label className="block text-sm">
+        Velocidad 𝓣
+        <input
+          type="range"
+          min={0.1}
+          max={3}
+          step={0.1}
+          className="w-full"
+          value={speed}
+          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+        />
+        <div className="text-xs mt-1">{speed.toFixed(1)}x</div>
+      </label>
+      <label className="block text-sm">
+        Balance Ω/ℂ
+        <input
+          type="range"
+          min={-1}
+          max={1}
+          step={0.01}
+          className="w-full"
+          value={balance}
+          onChange={(e) => setBalance(parseFloat(e.target.value))}
+        />
+        <div className="text-xs mt-1">{balance.toFixed(2)}</div>
+      </label>
+    </div>
+  );
+}

--- a/src/components/KernelEditor.tsx
+++ b/src/components/KernelEditor.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+const sharpenPreset = [0, -1, 0, -1, 5, -1, 0, -1, 0];
+const smoothPreset = [
+  0.07, 0.12, 0.07,
+  0.12, 0.26, 0.12,
+  0.07, 0.12, 0.07,
+];
+
+export function KernelEditor({ kernel, setKernel }: { kernel: number[]; setKernel: (k: number[]) => void; }) {
+  const change = (i: number, val: number) => {
+    const next = [...kernel];
+    next[i] = val;
+    setKernel(next);
+  };
+  const normalize = () => {
+    const sum = kernel.reduce((a, b) => a + b, 0) || 1;
+    setKernel(kernel.map((v) => v / sum));
+  };
+  return (
+    <div className="bg-slate-900/70 rounded-2xl p-4 space-y-4">
+      <h2 className="font-semibold">Editor de 𝓛(x) — kernel 3×3</h2>
+      <div className="grid grid-cols-3 gap-2">
+        {kernel.map((v, i) => (
+          <input
+            key={i}
+            type="number"
+            step="0.01"
+            value={v}
+            onChange={(e) => change(i, parseFloat(e.target.value))}
+            className="w-full rounded-md bg-slate-800 p-1 text-sm"
+          />
+        ))}
+      </div>
+      <div className="flex gap-2 flex-wrap text-sm">
+        <button className="px-2 py-1 rounded-md bg-slate-800" onClick={normalize}>Normalizar</button>
+        <button className="px-2 py-1 rounded-md bg-slate-800" onClick={() => setKernel(sharpenPreset)}>Afilado</button>
+        <button className="px-2 py-1 rounded-md bg-slate-800" onClick={() => setKernel(smoothPreset)}>Suavizado</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -17,11 +17,17 @@ export function LinePlot({
       />
     );
   }
+  // determine dynamic range and extend it by 40% so the waveform fits with
+  // additional headroom when zoomed out
   const min = Math.min(...data);
   const max = Math.max(...data);
-  const range = max - min || 1;
+  const mid = (min + max) / 2;
+  const half = ((max - min) / 2 || 0.5) * 1.4; // 40% zoom-out
+  const lo = mid - half;
+  const hi = mid + half;
+  const range = hi - lo || 1;
   const points = data
-    .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - (v - min) / range) * 100}`)
+    .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - (v - lo) / range) * 100}`)
     .join(" ");
   return (
     <svg

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -17,8 +17,11 @@ export function LinePlot({
       />
     );
   }
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
   const points = data
-    .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - v) * 100}`)
+    .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - (v - min) / range) * 100}`)
     .join(" ");
   return (
     <svg

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -1,14 +1,36 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import type { Snapshot } from "./PhiCanvas";
 
 export function LinePlot({
-  data,
+  snapshot,
+  onHistory,
   color = "#39c0ba",
   className = "h-24 bg-slate-800",
 }: {
-  data: number[];
+  snapshot: Snapshot;
+  onHistory?: (hist: number[]) => void;
   color?: string;
   className?: string;
 }) {
+  const [data, setData] = useState<number[]>([]);
+  const lastT = useRef(0);
+
+  useEffect(() => {
+    if (snapshot.t === 0) {
+      setData([]);
+      onHistory?.([]);
+      lastT.current = 0;
+      return;
+    }
+    if (snapshot.t === lastT.current) return; // paused or no progress
+    setData((arr) => {
+      const next = [...arr.slice(-29), snapshot.energy];
+      onHistory?.(next);
+      return next;
+    });
+    lastT.current = snapshot.t;
+  }, [snapshot, onHistory]);
+
   if (data.length < 2) {
     return (
       <svg
@@ -17,18 +39,18 @@ export function LinePlot({
       />
     );
   }
-  // determine dynamic range and extend it by 60% so the waveform fits with
-  // additional headroom when zoomed out
+
   const min = Math.min(...data);
   const max = Math.max(...data);
   const mid = (min + max) / 2;
-  const half = ((max - min) / 2 || 0.5) * 1.6; // 60% zoom-out
+  const half = ((max - min) / 2 || 0.5) * 1.6;
   const lo = mid - half;
   const hi = mid + half;
   const range = hi - lo || 1;
   const points = data
     .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - (v - lo) / range) * 100}`)
     .join(" ");
+
   return (
     <svg
       viewBox="0 0 100 100"

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export function LinePlot({ data }: { data: number[] }) {
+  if (data.length < 2) {
+    return <svg viewBox="0 0 100 100" className="w-full h-24 bg-slate-800 rounded-md" />;
+  }
+  const points = data.map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - v) * 100}`).join(" ");
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-24 bg-slate-800 rounded-md" preserveAspectRatio="none">
+      <polyline points={points} fill="none" stroke="#6cf" strokeWidth={2} />
+    </svg>
+  );
+}

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -1,13 +1,32 @@
 import React from "react";
 
-export function LinePlot({ data }: { data: number[] }) {
+export function LinePlot({
+  data,
+  color = "#39c0ba",
+  className = "",
+}: {
+  data: number[];
+  color?: string;
+  className?: string;
+}) {
   if (data.length < 2) {
-    return <svg viewBox="0 0 100 100" className="w-full h-24 bg-slate-800 rounded-md" />;
+    return (
+      <svg
+        viewBox="0 0 100 100"
+        className={`w-full h-24 bg-slate-800 rounded-md ${className}`}
+      />
+    );
   }
-  const points = data.map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - v) * 100}`).join(" ");
+  const points = data
+    .map((v, i) => `${(i / (data.length - 1)) * 100},${(1 - v) * 100}`)
+    .join(" ");
   return (
-    <svg viewBox="0 0 100 100" className="w-full h-24 bg-slate-800 rounded-md" preserveAspectRatio="none">
-      <polyline points={points} fill="none" stroke="#6cf" strokeWidth={2} />
+    <svg
+      viewBox="0 0 100 100"
+      className={`w-full h-24 bg-slate-800 rounded-md ${className}`}
+      preserveAspectRatio="none"
+    >
+      <polyline points={points} fill="none" stroke={color} strokeWidth={2} />
     </svg>
   );
 }

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export function LinePlot({
   data,
   color = "#39c0ba",
-  className = "",
+  className = "h-24 bg-slate-800",
 }: {
   data: number[];
   color?: string;
@@ -13,7 +13,7 @@ export function LinePlot({
     return (
       <svg
         viewBox="0 0 100 100"
-        className={`w-full h-24 bg-slate-800 rounded-md ${className}`}
+        className={`w-full rounded-md ${className}`}
       />
     );
   }
@@ -23,7 +23,7 @@ export function LinePlot({
   return (
     <svg
       viewBox="0 0 100 100"
-      className={`w-full h-24 bg-slate-800 rounded-md ${className}`}
+      className={`w-full rounded-md ${className}`}
       preserveAspectRatio="none"
     >
       <polyline points={points} fill="none" stroke={color} strokeWidth={2} />

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -17,12 +17,12 @@ export function LinePlot({
       />
     );
   }
-  // determine dynamic range and extend it by 40% so the waveform fits with
+  // determine dynamic range and extend it by 60% so the waveform fits with
   // additional headroom when zoomed out
   const min = Math.min(...data);
   const max = Math.max(...data);
   const mid = (min + max) / 2;
-  const half = ((max - min) / 2 || 0.5) * 1.4; // 40% zoom-out
+  const half = ((max - min) / 2 || 0.5) * 1.6; // 60% zoom-out
   const lo = mid - half;
   const hi = mid + half;
   const range = hi - lo || 1;

--- a/src/components/PhiCanvas.tsx
+++ b/src/components/PhiCanvas.tsx
@@ -15,7 +15,7 @@ export function PhiCanvas({
   paletteIndex = 0,
   className = "h-48",
 }: {
-  possibilities: { energy: number; symmetry: number; curvature: number }[];
+  possibilities: { energy: number; symmetry: number; curvature: number; phase: number }[];
   timeline: { t: number; score: number }[];
   t: number;
   speed?: number;
@@ -40,8 +40,8 @@ export function PhiCanvas({
     // Golden spiral particles (Φ fluctuations)
     const golden = Math.PI * (3 - Math.sqrt(5));
     possibilities.forEach((p, i) => {
-      const r = 20 + p.energy * 60 + 2 * Math.sin(t * 0.05 * speed + i);
-      const ang = i * golden + t * 0.02 * speed + p.symmetry * 4;
+      const r = 20 + p.energy * 60 + 2 * Math.sin(p.phase);
+      const ang = i * golden + p.phase + p.symmetry * 4;
       const x = W / 2 + r * Math.cos(ang);
       const y = H / 2 + r * Math.sin(ang);
       const hue = (p.energy * 180 + p.symmetry * 180) % 360;

--- a/src/components/PhiCanvas.tsx
+++ b/src/components/PhiCanvas.tsx
@@ -55,6 +55,7 @@ export function PhiCanvas({
     ctx.shadowBlur = 0;
     for (const e of timeline.slice(-8)) {
       const phase = (t - e.t) * 0.05;
+      if (phase < 0) continue; // ignore events from future frames after resume
       const alpha = Math.max(0, 0.6 - phase * 0.08);
       if (alpha <= 0) continue;
       ctx.strokeStyle = `rgba(255,255,255,${alpha})`;
@@ -62,7 +63,8 @@ export function PhiCanvas({
       const cx = (e.score * 997) % W;
       const cy = (e.score * 661) % H;
       ctx.beginPath();
-      ctx.arc(cx, cy, 12 + phase * 12, 0, Math.PI * 2);
+      const radius = 12 + phase * 12;
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
       ctx.stroke();
     }
   }, [possibilities, timeline, t, paletteIndex]);

--- a/src/components/PhiCanvas.tsx
+++ b/src/components/PhiCanvas.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from "react";
+
+const PALETTES: string[][] = [
+  ["#7dd3fc","#a78bfa","#f0abfc","#f472b6","#60a5fa"],
+  ["#fef08a","#fca5a5","#fdba74","#f97316","#fde68a"],
+  ["#34d399","#22d3ee","#38bdf8","#a7f3d0","#f5d0fe"],
+  ["#ef4444","#f59e0b","#10b981","#3b82f6","#8b5cf6"],
+];
+
+export function PhiCanvas({
+  possibilities,
+  timeline,
+  t,
+  paletteIndex = 0,
+  className = "h-48",
+}: {
+  possibilities: { energy: number; symmetry: number; curvature: number }[];
+  timeline: { t: number; score: number }[];
+  t: number;
+  paletteIndex?: number;
+  className?: string;
+}) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const cvs = ref.current!;
+    const ctx = cvs.getContext("2d")!;
+    const W = (cvs.width = cvs.clientWidth);
+    const H = (cvs.height = cvs.clientHeight);
+
+    // Background gradient inspired by multiverse palettes
+    const pal = PALETTES[paletteIndex % PALETTES.length];
+    const grad = ctx.createLinearGradient(0, 0, W, H);
+    pal.forEach((c, i) => grad.addColorStop(i / (pal.length - 1), c));
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, W, H);
+
+    // Golden spiral particles (Φ fluctuations)
+    const golden = Math.PI * (3 - Math.sqrt(5));
+    possibilities.forEach((p, i) => {
+      const r = 20 + p.energy * 60 + 2 * Math.sin(t * 0.05 + i);
+      const ang = i * golden + t * 0.02 + p.symmetry * 4;
+      const x = W / 2 + r * Math.cos(ang);
+      const y = H / 2 + r * Math.sin(ang);
+      const hue = (p.energy * 180 + p.symmetry * 180) % 360;
+      ctx.beginPath();
+      ctx.fillStyle = `hsla(${hue},80%,60%,0.85)`;
+      ctx.shadowColor = `hsla(${hue},100%,70%,0.9)`;
+      ctx.shadowBlur = 10;
+      ctx.arc(x, y, 2 + 2 * Math.abs(p.curvature), 0, Math.PI * 2);
+      ctx.fill();
+    });
+
+    // ε event pulses
+    ctx.shadowBlur = 0;
+    for (const e of timeline.slice(-8)) {
+      const phase = (t - e.t) * 0.05;
+      const alpha = Math.max(0, 0.6 - phase * 0.08);
+      if (alpha <= 0) continue;
+      ctx.strokeStyle = `rgba(255,255,255,${alpha})`;
+      ctx.lineWidth = 1 + 2 * (1 - alpha);
+      const cx = (e.score * 997) % W;
+      const cy = (e.score * 661) % H;
+      ctx.beginPath();
+      ctx.arc(cx, cy, 12 + phase * 12, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }, [possibilities, timeline, t, paletteIndex]);
+
+  return <canvas ref={ref} className={`w-full rounded-xl ${className}`} />;
+}
+

--- a/src/components/PhiCanvas.tsx
+++ b/src/components/PhiCanvas.tsx
@@ -11,12 +11,14 @@ export function PhiCanvas({
   possibilities,
   timeline,
   t,
+  speed = 1,
   paletteIndex = 0,
   className = "h-48",
 }: {
   possibilities: { energy: number; symmetry: number; curvature: number }[];
   timeline: { t: number; score: number }[];
   t: number;
+  speed?: number;
   paletteIndex?: number;
   className?: string;
 }) {
@@ -38,8 +40,8 @@ export function PhiCanvas({
     // Golden spiral particles (Φ fluctuations)
     const golden = Math.PI * (3 - Math.sqrt(5));
     possibilities.forEach((p, i) => {
-      const r = 20 + p.energy * 60 + 2 * Math.sin(t * 0.05 + i);
-      const ang = i * golden + t * 0.02 + p.symmetry * 4;
+      const r = 20 + p.energy * 60 + 2 * Math.sin(t * 0.05 * speed + i);
+      const ang = i * golden + t * 0.02 * speed + p.symmetry * 4;
       const x = W / 2 + r * Math.cos(ang);
       const y = H / 2 + r * Math.sin(ang);
       const hue = (p.energy * 180 + p.symmetry * 180) % 360;
@@ -54,7 +56,7 @@ export function PhiCanvas({
     // ε event pulses
     ctx.shadowBlur = 0;
     for (const e of timeline.slice(-8)) {
-      const phase = (t - e.t) * 0.05;
+      const phase = (t - e.t) * 0.05 * speed;
       if (phase < 0) continue; // ignore events from future frames after resume
       const alpha = Math.max(0, 0.6 - phase * 0.08);
       if (alpha <= 0) continue;
@@ -67,7 +69,7 @@ export function PhiCanvas({
       ctx.arc(cx, cy, radius, 0, Math.PI * 2);
       ctx.stroke();
     }
-  }, [possibilities, timeline, t, paletteIndex]);
+  }, [possibilities, timeline, t, speed, paletteIndex]);
 
   return <canvas ref={ref} className={`w-full rounded-xl ${className}`} />;
 }

--- a/src/components/PhiCanvas.tsx
+++ b/src/components/PhiCanvas.tsx
@@ -1,23 +1,26 @@
 import React, { useEffect, useRef } from "react";
 
 const PALETTES: string[][] = [
-  ["#7dd3fc","#a78bfa","#f0abfc","#f472b6","#60a5fa"],
-  ["#fef08a","#fca5a5","#fdba74","#f97316","#fde68a"],
-  ["#34d399","#22d3ee","#38bdf8","#a7f3d0","#f5d0fe"],
-  ["#ef4444","#f59e0b","#10b981","#3b82f6","#8b5cf6"],
+  ["#7dd3fc", "#a78bfa", "#f0abfc", "#f472b6", "#60a5fa"],
+  ["#fef08a", "#fca5a5", "#fdba74", "#f97316", "#fde68a"],
+  ["#34d399", "#22d3ee", "#38bdf8", "#a7f3d0", "#f5d0fe"],
+  ["#ef4444", "#f59e0b", "#10b981", "#3b82f6", "#8b5cf6"],
 ];
 
+export type Snapshot = {
+  possibilities: { energy: number; symmetry: number; curvature: number; phase: number }[];
+  timeline: { t: number; score: number }[];
+  t: number;
+  energy: number;
+};
+
 export function PhiCanvas({
-  possibilities,
-  timeline,
-  t,
+  snapshot,
   speed = 1,
   paletteIndex = 0,
   className = "h-48",
 }: {
-  possibilities: { energy: number; symmetry: number; curvature: number; phase: number }[];
-  timeline: { t: number; score: number }[];
-  t: number;
+  snapshot: Snapshot;
   speed?: number;
   paletteIndex?: number;
   className?: string;
@@ -29,6 +32,8 @@ export function PhiCanvas({
     const ctx = cvs.getContext("2d")!;
     const W = (cvs.width = cvs.clientWidth);
     const H = (cvs.height = cvs.clientHeight);
+
+    const { possibilities, timeline, t } = snapshot;
 
     // Background gradient inspired by multiverse palettes
     const pal = PALETTES[paletteIndex % PALETTES.length];
@@ -69,7 +74,7 @@ export function PhiCanvas({
       ctx.arc(cx, cy, radius, 0, Math.PI * 2);
       ctx.stroke();
     }
-  }, [possibilities, timeline, t, speed, paletteIndex]);
+  }, [snapshot, speed, paletteIndex]);
 
   return <canvas ref={ref} className={`w-full rounded-xl ${className}`} />;
 }


### PR DESCRIPTION
## Summary
- replace colorful Phi canvas with a numerical line plot of averaged energy per universe cell
- add reusable `LinePlot` component
- remove unused palette selector for a cleaner scientific look

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c326ecc30c8320870fea6d3460213e