### PR TITLE
feat: adapt lattice based on spark activity

### DIFF
--- a/src/App_solis_example_patch.tsx
+++ b/src/App_solis_example_patch.tsx
@@ -10,7 +10,7 @@ import { EventLog } from "./components/EventLog";
 export default function AppSolisExample() {
   const { L, setL, theta, setTheta,
     resonanceNow, pushParticles, tick,
-    metricsDelta, eventsLog, resetMetrics } = useSolisModel();
+    timeField, eventsLog, resetTimeField } = useSolisModel();
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -38,8 +38,8 @@ export default function AppSolisExample() {
         setL={setL}
         theta={theta}
         setTheta={setTheta}
-        metricsDelta={metricsDelta}
-        onResetMetrics={resetMetrics}
+        timeField={timeField}
+        onResetTime={resetTimeField}
       />
       <EventLog events={eventsLog} />
       <div style={{opacity:0.7, fontSize:12}}>

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -5,11 +5,11 @@ type Props = {
   setL: (v: number[]) => void;
   theta: number;
   setTheta: (v: number) => void;
-  metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
-  onResetMetrics?: () => void;
+  timeField: { dEntropy: number; dDensity: number; dClusters: number };
+  onResetTime?: () => void;
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics }: Props) {
+export function SensitivityPanel({ L, setL, theta, setTheta, timeField, onResetTime }: Props) {
   const setIdx = (i: number, val: number) => {
     const next = [...L];
     next[i] = val;
@@ -35,11 +35,11 @@ export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onRes
         <code>{theta.toFixed(2)}</code>
       </div>
       <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8}}>
-        <MiniStat label="Δ Entropía" value={metricsDelta.dEntropy} />
-        <MiniStat label="Δ Densidad" value={metricsDelta.dDensity} />
-        <MiniStat label="Δ Clusters" value={metricsDelta.dClusters} />
+        <MiniStat label="Δ Entropía" value={timeField.dEntropy} />
+        <MiniStat label="Δ Densidad" value={timeField.dDensity} />
+        <MiniStat label="Δ Clusters" value={timeField.dClusters} />
       </div>
-      <button onClick={onResetMetrics} style={{justifySelf:"start", padding:"6px 10px"}}>Reiniciar Δ</button>
+      <button onClick={onResetTime} style={{justifySelf:"start", padding:"6px 10px"}}>Reiniciar Δ</button>
     </div>
   );
 }

--- a/src/engine.js
+++ b/src/engine.js
@@ -85,7 +85,8 @@ export function resonance(phi, shaped, t = 0){
 }
 
 export function tick(state){
-  const {grid, preset, epsilon, rng, drift, customKernel} = state;
+  const {grid, preset, epsilon, rng, drift, customKernel, friction = 0} = state;
+  const f = Math.min(Math.max(friction, 0), 1);
   state.t = (state.t ?? 0) + 1;
   for(let i=0;i<state.phi.length;i++){
     state.phi[i] = (1-drift)*state.phi[i] + drift*rng.next();
@@ -117,7 +118,9 @@ export function tick(state){
   const shapedNext = applyLattice(state.phi, grid, "custom", blended);
   let diff = 0;
   for(let i=0;i<shapedNext.length;i++){
-    diff += Math.abs(shapedNext[i] - shapedPrev[i]);
+    const attenuated = shapedNext[i] * (1 - f);
+    diff += Math.abs(attenuated - shapedPrev[i]);
+    shapedNext[i] = attenuated;
   }
   state.timeField = diff / shapedNext.length;
   state.shaped = shapedNext;

--- a/src/lib/solisModel.ts
+++ b/src/lib/solisModel.ts
@@ -39,12 +39,16 @@ export function useSolisModel() {
 
     // métricas y 𝓣 (∂R/∂𝓛 estimado por diferencia)
     const m = computeMetrics(res, theta);
-    const tField = {
+    const tFieldRaw = {
       dEntropy: m.entropy - lastMetricsRef.current.entropy,
       dDensity: m.density - lastMetricsRef.current.density,
       dClusters: m.clusters - lastMetricsRef.current.clusters,
     };
-    setTimeField(tField);
+    setTimeField(prev => ({
+      dEntropy: (prev.dEntropy ?? 0) * 0.8 + tFieldRaw.dEntropy * 0.2,
+      dDensity: (prev.dDensity ?? 0) * 0.8 + tFieldRaw.dDensity * 0.2,
+      dClusters: (prev.dClusters ?? 0) * 0.8 + tFieldRaw.dClusters * 0.2,
+    }));
     lastMetricsRef.current = m;
 
     // eventos ε modulados por 𝓣

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ const frictionEl = $("#friction");
 const presetEl = $("#preset");
 const kpiEvents = $("#kpiEvents");
 const kpiRes = $("#kpiRes");
+const kpiEnergy = $("#kpiEnergy");
 const kpiT = $("#kpiT");
 const kpiFrames = $("#kpiFrames");
 const bufferBar = $("#bufferBar");
@@ -58,17 +59,20 @@ kernelSmooth.addEventListener("click", ()=>{
 });
 
 function makeState({seed, grid, preset, friction}){
+  const phi = makePhi(seed, grid);
   return {
     seed, grid, preset,
     epsilon: 1.4,
     rng: new RNG(seed ^ 0x9e3779b9),
-    phi: makePhi(seed, grid),
+    phi,
+    initialPhi: Float32Array.from(phi),
     shaped: new Float32Array(grid*grid),
     events: 0,
     sparks: [],
     drift: 0.02,
     friction: friction ?? 0,
     customKernel: customKernel.slice(),
+    energy: 1,
     // Timeline buffers
     timeline: [], // array of snapshots
     resSeries: [],
@@ -212,8 +216,10 @@ function loop(t){
   // KPIs
   const ev = states.reduce((a,s)=> a+s.events, 0);
   const resAvg = states.reduce((a,s)=> a+(s.lastRes||0), 0)/states.length;
+  const energyAvg = states.reduce((a,s)=> a+(s.energy||0), 0)/states.length;
   kpiEvents.textContent = String(ev);
   kpiRes.textContent = (resAvg||0).toFixed(2);
+  if(kpiEnergy) kpiEnergy.textContent = energyAvg.toFixed(2);
 
   drawCharts();
   requestAnimationFrame(loop);

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const $ = (sel)=> document.querySelector(sel);
 const seedEl = $("#seed");
 const gridEl = $("#grid");
 const speedEl = $("#speed");
+const frictionEl = $("#friction");
 const presetEl = $("#preset");
 const kpiEvents = $("#kpiEvents");
 const kpiRes = $("#kpiRes");
@@ -56,7 +57,7 @@ kernelSmooth.addEventListener("click", ()=>{
   if(presetEl.value==="custom") applyGlobalParamChange();
 });
 
-function makeState({seed, grid, preset}){
+function makeState({seed, grid, preset, friction}){
   return {
     seed, grid, preset,
     epsilon: 1.4,
@@ -66,6 +67,7 @@ function makeState({seed, grid, preset}){
     events: 0,
     sparks: [],
     drift: 0.02,
+    friction: friction ?? 0,
     customKernel: customKernel.slice(),
     // Timeline buffers
     timeline: [], // array of snapshots
@@ -78,7 +80,8 @@ let params = {
   seed: Number(seedEl.value),
   grid: Number(gridEl.value),
   preset: presetEl.value,
-  speed: Number(speedEl.value)
+  speed: Number(speedEl.value),
+  friction: Number(frictionEl?.value || 0)
 };
 
 let running = true;
@@ -105,7 +108,8 @@ function applyGlobalParamChange(){
     seed: Number(seedEl.value),
     grid: Number(gridEl.value),
     preset: presetEl.value,
-    speed: Number(speedEl.value)
+    speed: Number(speedEl.value),
+    friction: Number(frictionEl?.value || 0)
   };
   for(let i=0;i<states.length;i++){
     const keepE = states[i].events;
@@ -124,6 +128,7 @@ seedEl.addEventListener("input", applyGlobalParamChange);
 gridEl.addEventListener("input", applyGlobalParamChange);
 presetEl.addEventListener("change", applyGlobalParamChange);
 speedEl.addEventListener("input", applyGlobalParamChange);
+frictionEl?.addEventListener("input", applyGlobalParamChange);
 
 $("#startAll").addEventListener("click", ()=> running=true);
 $("#pauseAll").addEventListener("click", ()=> running=false);


### PR DESCRIPTION
## Summary
- add reusable smooth and rigid kernel constants
- blend kernels based on spark activity to update lattice each tick

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5738c98288320844041e674a7c015