### PR TITLE
feat: model Alef structure and metrics

### DIFF
--- a/src/App_solis_example_patch.tsx
+++ b/src/App_solis_example_patch.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useSolisModel } from "./lib/solisModel";
 import type { Particle } from "./lib/resonance";
+import { computeAlef } from "./lib/alef";
 import { SensitivityPanel } from "./components/SensitivityPanel";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 import { EventLog } from "./components/EventLog";
@@ -10,7 +11,9 @@ import { EventLog } from "./components/EventLog";
 export default function AppSolisExample() {
   const { L, setL, theta, setTheta,
     resonanceNow, pushParticles, tick,
-    metricsDelta, eventsLog, resetMetrics } = useSolisModel();
+    metricsDelta, eventsLog, resetMetrics,
+    timeField } = useSolisModel();
+  const alef = computeAlef({ L, resonance: resonanceNow, timeField });
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -40,6 +43,7 @@ export default function AppSolisExample() {
         setTheta={setTheta}
         metricsDelta={metricsDelta}
         onResetMetrics={resetMetrics}
+        alef={alef}
       />
       <EventLog events={eventsLog} />
       <div style={{opacity:0.7, fontSize:12}}>

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -7,9 +7,10 @@ type Props = {
   setTheta: (v: number) => void;
   metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
   onResetMetrics?: () => void;
+  alef?: { upperYud: number; vav: number; lowerYud: number };
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics }: Props) {
+export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics, alef }: Props) {
   const setIdx = (i: number, val: number) => {
     const next = [...L];
     next[i] = val;
@@ -40,6 +41,13 @@ export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onRes
         <MiniStat label="Δ Clusters" value={metricsDelta.dClusters} />
       </div>
       <button onClick={onResetMetrics} style={{justifySelf:"start", padding:"6px 10px"}}>Reiniciar Δ</button>
+      {alef && (
+        <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8, marginTop:8}}>
+          <MiniStat label="Ω (Yud)" value={alef.upperYud} />
+          <MiniStat label="Φ∘𝓛 (Vav)" value={alef.vav} />
+          <MiniStat label="R (Yud)" value={alef.lowerYud} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/alef.ts
+++ b/src/lib/alef.ts
@@ -1,0 +1,32 @@
+import { clamp01 } from "./resonance";
+
+/**
+ * Representation of Alef (י–ו–י) linking Ω, Φ∘𝓛 and R.
+ * upperYud -> Ω (silent source)
+ * vav      -> Φ structured by 𝓛
+ * lowerYud -> R (manifest reality)
+ */
+export interface Alef {
+  upperYud: number; // Ω
+  vav: number;      // Φ ∘ 𝓛
+  lowerYud: number; // R
+}
+
+/**
+ * State needed to derive Alef components.
+ */
+export interface AlefState {
+  timeField: number;    // 𝓣 derivative field approximating distance to Ω
+  L: number[];          // lattice parameters 𝓛(x)
+  resonance: number;    // ℜ or manifested intensity (R)
+}
+
+/**
+ * Derive Alef symbolic components from engine state.
+ */
+export function computeAlef(state: AlefState): Alef {
+  const upperYud = clamp01(1 - state.timeField); // Ω : more silence when 𝓣 small
+  const vav = clamp01(state.L.reduce((a, b) => a + b, 0) / state.L.length); // Φ∘𝓛
+  const lowerYud = clamp01(state.resonance * vav); // R as projection through 𝓛
+  return { upperYud, vav, lowerYud };
+}


### PR DESCRIPTION
## Summary
- add Alef helper to derive Ω, Φ∘𝓛 and R from engine state
- surface Alef metrics in SensitivityPanel for symbolic display
- compute Alef in demo app and forward to metrics panel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb3f0584832088fbf8deb4fa1cc0