### PR TITLE
feat: model Alef structure and metrics

### DIFF
--- a/src/App_solis_example_patch.tsx
+++ b/src/App_solis_example_patch.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { useSolisModel } from "./lib/solisModel";
 import type { Particle } from "./lib/resonance";
+import { computeAlef } from "./lib/alef";
 import { SensitivityPanel } from "./components/SensitivityPanel";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 import { EventLog } from "./components/EventLog";
@@ -10,7 +11,10 @@ import { EventLog } from "./components/EventLog";
 export default function AppSolisExample() {
   const { L, setL, theta, setTheta,
     resonanceNow, pushParticles, tick,
-    metricsDelta, eventsLog, resetMetrics } = useSolisModel();
+    metricsDelta, eventsLog, resetMetrics,
+    timeField } = useSolisModel();
+  const alef = computeAlef({ L, resonance: resonanceNow, timeField });
+  const realityRatio = alef.vav ? alef.upperYud / alef.vav : 0;
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -40,6 +44,8 @@ export default function AppSolisExample() {
         setTheta={setTheta}
         metricsDelta={metricsDelta}
         onResetMetrics={resetMetrics}
+        alef={alef}
+        realityRatio={realityRatio}
       />
       <EventLog events={eventsLog} />
       <div style={{opacity:0.7, fontSize:12}}>

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -7,9 +7,11 @@ type Props = {
   setTheta: (v: number) => void;
   metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
   onResetMetrics?: () => void;
+  alef?: { upperYud: number; vav: number; lowerYud: number };
+  realityRatio?: number;
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics }: Props) {
+export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics, alef, realityRatio }: Props) {
   const setIdx = (i: number, val: number) => {
     const next = [...L];
     next[i] = val;
@@ -40,6 +42,23 @@ export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onRes
         <MiniStat label="Δ Clusters" value={metricsDelta.dClusters} />
       </div>
       <button onClick={onResetMetrics} style={{justifySelf:"start", padding:"6px 10px"}}>Reiniciar Δ</button>
+      {alef && (
+        <div
+          style={{
+            display:"grid",
+            gridTemplateColumns:`repeat(${realityRatio !== undefined ? 4 : 3},1fr)`,
+            gap:8,
+            marginTop:8
+          }}
+        >
+          <MiniStat label="Ω (Yud)" value={alef.upperYud} />
+          <MiniStat label="Φ∘𝓛 (Vav)" value={alef.vav} />
+          <MiniStat label="R (Yud)" value={alef.lowerYud} />
+          {typeof realityRatio === "number" && (
+            <MiniStat label="Ω/(Φ∘𝓛)" value={realityRatio} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/engine.js
+++ b/src/engine.js
@@ -8,6 +8,10 @@
 // R: rendered canvas state
 // 𝓡ₐ: feedback: R nudges 𝓛 over time
 
+// Axioma XI — coeficiente de proporcionalidad
+// Ω se modela como una constante absoluta en el motor.
+const OMEGA = 1;
+
 export class RNG {
   constructor(seed=1234){
     this.s = seed >>> 0;
@@ -114,6 +118,11 @@ export function tick(state){
       state.shaped[i] *= (1 - mu);
     }
   }
+  // Axioma XI: R como cociente Ω/(Φ∘𝓛)
+  let phiL = 0;
+  for(let i=0;i<state.shaped.length;i++){ phiL += state.shaped[i]; }
+  phiL /= state.shaped.length;
+  state.realityRatio = phiL !== 0 ? OMEGA / phiL : Infinity;
   // 𝓣: derivative of R with respect to lattice variation
   if(state.prevShaped){
     let diffR=0;

--- a/src/lib/alef.ts
+++ b/src/lib/alef.ts
@@ -1,0 +1,32 @@
+import { clamp01 } from "./resonance";
+
+/**
+ * Representation of Alef (י–ו–י) linking Ω, Φ∘𝓛 and R.
+ * upperYud -> Ω (silent source)
+ * vav      -> Φ structured by 𝓛
+ * lowerYud -> R (manifest reality)
+ */
+export interface Alef {
+  upperYud: number; // Ω
+  vav: number;      // Φ ∘ 𝓛
+  lowerYud: number; // R
+}
+
+/**
+ * State needed to derive Alef components.
+ */
+export interface AlefState {
+  timeField: number;    // 𝓣 derivative field approximating distance to Ω
+  L: number[];          // lattice parameters 𝓛(x)
+  resonance: number;    // ℜ or manifested intensity (R)
+}
+
+/**
+ * Derive Alef symbolic components from engine state.
+ */
+export function computeAlef(state: AlefState): Alef {
+  const upperYud = clamp01(1 - state.timeField); // Ω : more silence when 𝓣 small
+  const vav = clamp01(state.L.reduce((a, b) => a + b, 0) / state.L.length); // Φ∘𝓛
+  const lowerYud = clamp01(state.resonance * vav); // R as projection through 𝓛
+  return { upperYud, vav, lowerYud };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ const kpiEvents = $("#kpiEvents");
 const kpiRes = $("#kpiRes");
 const kpiT = $("#kpiT");
 const kpiFrames = $("#kpiFrames");
+const kpiRatio = $("#kpiRatio");
 const bufferBar = $("#bufferBar");
 const c1 = $("#c1"), c2 = $("#c2"), c3 = $("#c3");
 const chart1=$("#chart1"), chart2=$("#chart2"), chart3=$("#chart3");
@@ -69,6 +70,7 @@ function makeState({seed, grid, preset, mu}){
     drift: 0.02,
     mu: mu ?? 0,
     customKernel: customKernel.slice(),
+    realityRatio: 0,
     // Timeline buffers
     timeline: [], // array of snapshots
     resSeries: [],
@@ -214,6 +216,8 @@ function loop(t){
   const resAvg = states.reduce((a,s)=> a+(s.lastRes||0), 0)/states.length;
   kpiEvents.textContent = String(ev);
   kpiRes.textContent = (resAvg||0).toFixed(2);
+  const ratioAvg = states.reduce((a,s)=> a+(s.realityRatio||0), 0)/states.length;
+  if(kpiRatio) kpiRatio.textContent = (ratioAvg||0).toFixed(2);
 
   drawCharts();
   requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- add Alef helper to derive Ω, Φ∘𝓛 and R from engine state
- surface Alef metrics in SensitivityPanel for symbolic display
- compute Alef in demo app and forward to metrics panel
- introduce Ω constant and compute ontological reality ratio
- expose reality ratio metric in engine UI and sensitivity panel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb3f0584832088fbf8deb4fa1cc0