### PR TITLE
Fix cluster counting in resonance utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Este proyecto es un ejemplo mínimo que combina **React**, **Vite**, **Tailwind 
 3. Compila la aplicación: `npm run build`
 4. Inicia el servidor: `npm start`
 
+## Parámetro μ
+El panel de sensibilidad expone **μ**, la fricción ontológica descrita en el Axioma IX. Un valor mayor de μ atenúa cada tic tanto al campo de potenciales Φ como a la estructura 𝓛, lo que reduce las métricas de resonancia y la intensidad mostrada en la visualización.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ,
 - Al aumentar `𝓡ₐ`, la lattice se aproxima gradualmente al promedio de las características Φ que generan eventos ε, ponderado por la resonancia y el campo temporal `𝓣`.
 - Con `𝓡ₐ = 0` la estructura permanece fija; valores mayores permiten estudiar el Axioma VIII (realidad autoactualizable) sin romper la independencia de la fricción, que sigue actuando únicamente sobre Φ.
 
+## Campo temporal 𝓣
+
+- Cada tic de la simulación registra el estado previo de 𝓛 y de las métricas de R (entropía, densidad y clusters de resonancia).
+- `𝓣` se calcula como la derivada discreta ∂R/∂𝓛 ≈ Δ‖R‖ / Δ‖𝓛‖: si la lattice cambia pero las métricas de la realidad apenas lo hacen, `𝓣` se reduce; cuando pequeñas variaciones estructurales producen grandes cambios en R, `𝓣` crece.
+- Este valor modulador aparece en la activación de eventos ε y en la retroalimentación `𝓡ₐ`, reforzando el Axioma IV donde el tiempo emerge del ritmo de actualización de R respecto a 𝓛.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Este proyecto es un ejemplo mínimo que combina **React**, **Vite**, **Tailwind 
 4. Inicia el servidor: `npm start`
 
 ## Parámetro μ
-El panel de sensibilidad expone **μ**, la fricción ontológica descrita en el Axioma IX. Un valor mayor de μ atenúa cada tic tanto al campo de potenciales Φ como a la estructura 𝓛, lo que reduce las métricas de resonancia y la intensidad mostrada en la visualización.
+El panel de sensibilidad expone **μ**, la fricción ontológica descrita en el Axioma IX. Un valor mayor de μ atenúa cada tic únicamente al campo de potenciales Φ, lo que reduce las métricas de resonancia y la intensidad mostrada en la visualización mientras 𝓛 permanece intacta.
 
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ,
   ```
   Los resultados se guardan en `reports/experimentos-<timestamp>.csv` y `.json`.
 
+Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida de los experimentos, consulta [docs/README-Experimentos.md](docs/README-Experimentos.md).
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ,
 - `𝓣` se calcula como la derivada discreta ∂R/∂𝓛 ≈ Δ‖R‖ / Δ‖𝓛‖: si la lattice cambia pero las métricas de la realidad apenas lo hacen, `𝓣` se reduce; cuando pequeñas variaciones estructurales producen grandes cambios en R, `𝓣` crece.
 - Este valor modulador aparece en la activación de eventos ε y en la retroalimentación `𝓡ₐ`, reforzando el Axioma IV donde el tiempo emerge del ritmo de actualización de R respecto a 𝓛.
 
+## Panel de resultados reproducibles
+
+- Desde el panel lateral puedes ejecutar un barrido automático de parámetros (`depth`, `boundaryNoise`, `kernelMix` y semillas) con más de 30 corridas.
+- El botón **Exportar reporte** descarga un CSV con todas las métricas (`R²` frente a perímetro/área, MSE de reconstrucción, varianza de ℜ, promedios de flujo) y una imagen PNG con la comparativa ley de área vs volumen.
+- También es posible generar los mismos archivos desde línea de comandos con:
+  ```bash
+  npx ts-node scripts/run_experiments.ts
+  ```
+  Los resultados se guardan en `reports/experimentos-<timestamp>.csv` y `.json`.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ,
 - `μ` únicamente amortigua las características de las partículas (Φ) durante cada `tick`.
 - La lattice 𝓛 no se escala ni se modifica por efecto de `μ`; su intensidad solo contribuye al componente estructural `μ𝓛` que se suma a la fricción efectiva.
 
+## Retroalimentación 𝓡ₐ sobre 𝓛
+
+- El modelo analítico ofrece un control `𝓡ₐ` que regula cómo la realidad manifestada (R) retroajusta la estructura limitante 𝓛.
+- Al aumentar `𝓡ₐ`, la lattice se aproxima gradualmente al promedio de las características Φ que generan eventos ε, ponderado por la resonancia y el campo temporal `𝓣`.
+- Con `𝓡ₐ = 0` la estructura permanece fija; valores mayores permiten estudiar el Axioma VIII (realidad autoactualizable) sin romper la independencia de la fricción, que sigue actuando únicamente sobre Φ.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ El panel de sensibilidad expone **μ₀**, la fricción ontológica base descrit
 
 De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ, pero crece proporcionalmente con la estructura limitante. 𝓛 permanece fija, aunque el incremento de su intensidad fortalece la fricción total `μΣ = μ₀ + μ𝓛`, reduciendo las métricas de resonancia y la energía visible.
 
+### Alcance de la fricción μ
+
+- `μ` únicamente amortigua las características de las partículas (Φ) durante cada `tick`.
+- La lattice 𝓛 no se escala ni se modifica por efecto de `μ`; su intensidad solo contribuye al componente estructural `μ𝓛` que se suma a la fricción efectiva.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Este proyecto es un ejemplo mínimo que combina **React**, **Vite**, **Tailwind 
 3. Compila la aplicación: `npm run build`
 4. Inicia el servidor: `npm start`
 
-## Parámetro μ
-El panel de sensibilidad expone **μ**, la fricción ontológica descrita en el Axioma IX. Un valor mayor de μ atenúa cada tic únicamente al campo de potenciales Φ, lo que reduce las métricas de resonancia y la intensidad mostrada en la visualización mientras 𝓛 permanece intacta.
+## Parámetro μ y congruencia con 𝓛
+El panel de sensibilidad expone **μ₀**, la fricción ontológica base descrita en el Axioma IX. La fricción efectiva aplicada en cada tic es la suma de esa base más la resistencia estructural inducida por 𝓛: a mayor magnitud de los pesos del kernel 3×3 (o del vector 𝓛 del modelo analítico), mayor es el aporte automático `μ𝓛`.
+
+De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ, pero crece proporcionalmente con la estructura limitante. 𝓛 permanece fija, aunque el incremento de su intensidad fortalece la fricción total `μΣ = μ₀ + μ𝓛`, reduciendo las métricas de resonancia y la energía visible.
 
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).

--- a/docs/README-Experimentos.md
+++ b/docs/README-Experimentos.md
@@ -1,0 +1,57 @@
+# Experimentos reproducibles del modelo Φ ∘ 𝓛(x)
+
+## Introducción
+Este documento detalla cómo ejecutar y comprender los experimentos reproducibles del simulador **BigBang_Final**. Resume la manera en la que el flujo de sucesos potenciales Φ es filtrado por las estructuras limitantes 𝓛 para generar realidades manifestadas R, siguiendo los axiomas del modelo metaontológico Φ ∘ 𝓛(x). La información aquí descrita amplía el README principal con contexto conceptual y no introduce cambios en el código ejecutable del proyecto.
+
+## Cómo ejecutar los experimentos (resumen técnico)
+Ejecuta los barridos automatizados de parámetros mediante:
+
+```bash
+npx ts-node scripts/run_experiments.ts
+```
+
+El comando crea reportes en `reports/experimentos-<timestamp>.csv` y `reports/experimentos-<timestamp>.json`, que incluyen métricas como \(R^2\) frente a perímetro/área, MSE de reconstrucción, varianzas de ℜ y promedios de flujo holográfico.
+
+## Mapa de Φ ∘ 𝓛(x) – Sucesos vs Limitantes
+| Sucesos y hechos posibles (Φ) | Estructuras limitantes (𝓛) |
+|--------------------------------|-----------------------------|
+| Fluctuaciones cuánticas del vacío | Principio de incertidumbre (Heisenberg) |
+| Creación/aniquilación de pares partícula–antipartícula | Conservación de energía y carga |
+| Oscilación de neutrinos | Matriz PMNS (mezcla de sabores), masa mínima de neutrinos |
+| Reacciones nucleares (fusión, fisión) | Fuerza nuclear fuerte y débil, barrera de Coulomb |
+| Tunelamiento cuántico | Probabilidad cuántica, función de onda, no-clonación |
+| Formación de moléculas y enlaces químicos | Constante de estructura fina (α), mecánica cuántica molecular |
+| Transiciones de fase (sólido–líquido–gas–plasma–BEC) | Termodinámica (leyes de conservación, entropía) |
+| Actividad volcánica, tectónica y sísmica | Física de materiales, gravedad, geodinámica |
+| Fenómenos atmosféricos (huracanes, auroras, arcoíris) | Termodinámica, electromagnetismo, dinámica de fluidos |
+| Mutación y evolución biológica | ADN, tasas de mutación, leyes de la selección natural |
+| Emergencia de conciencia | Neurobiología, coherencia cuántica (hipótesis en debate) |
+| Muerte y regeneración parcial | Límite de reparación celular, entropía biológica |
+| Formación de estrellas y planetas | Colapso gravitatorio, límite de Jeans |
+| Supernovas, hipernovas, kilonovas | Límite de Chandrasekhar, TOV |
+| Formación de agujeros negros | Relatividad general, horizonte de eventos |
+| Evaporación de agujeros negros (Hawking) | Mecánica cuántica + relatividad (aún no unificada) |
+| Colisiones galácticas | Gravedad newtoniana/relativista, conservación de momento |
+| Ondas gravitacionales | Relatividad general, energía gravitacional |
+| Expansión cósmica acelerada | Constante cosmológica Λ, energía oscura |
+| Posible Big Bang e inflaciones | Condiciones iniciales del universo, simetrías rotas |
+| Posibles universos burbuja | Modelos inflacionarios multiverso |
+| Lenguaje, cultura, sociedades | Neurociencia, evolución cognitiva, dinámica social |
+| Ciencia, arte, tecnología | Límites de energía y recursos disponibles |
+| Computación e inteligencia artificial | Teoría de la información, complejidad computacional |
+| Guerra y cooperación | Psicología, sociología, recursos materiales |
+| Colonización espacial | Ley de Tsiolkovsky, restricciones energéticas |
+| Ingeniería genética y biotecnología | Biología molecular, bioética, límites mutacionales |
+| Ciborgs y transhumanismo | Ingeniería biomédica, integración hombre-máquina |
+| Posible contacto extraterrestre | Límites de detección (SETI, paradoja de Fermi) |
+| Colonización interestelar | Relatividad especial (velocidad < c), energía finita |
+
+## Interpretación
+- **Φ (columna izquierda)** representa el abanico de sucesos posibles en el cosmos, desde procesos cuánticos hasta fenómenos sociales y tecnológicos.
+- **𝓛 (columna derecha)** describe las leyes, constantes y límites que estructuran o restringen esos sucesos, determinando qué potencialidades pueden manifestarse.
+- La realidad **R** surge como la intersección de ambos dominios: cuando un suceso posible cumple las condiciones limitantes, se actualiza como evento concreto.
+- Este marco es conceptual y no modifica el motor holográfico ni las rutinas de simulación.
+
+## Notas finales
+- La documentación de este archivo no altera el comportamiento de la aplicación ni introduce dependencias adicionales.
+- Para instrucciones generales del proyecto y enlaces adicionales, vuelve al [README principal](../README.md).

--- a/scripts/run_experiments.ts
+++ b/scripts/run_experiments.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  DEFAULT_BATCH_CONFIG,
+  formatExperimentCsv,
+  runBatchExperiments,
+} from "../src/lib/experiments";
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function main() {
+  const { results, summary } = runBatchExperiments();
+  const outDir = path.resolve(process.cwd(), "reports");
+  ensureDir(outDir);
+  const baseName = `experimentos-${timestamp()}`;
+  const csvPath = path.join(outDir, `${baseName}.csv`);
+  const jsonPath = path.join(outDir, `${baseName}.json`);
+
+  fs.writeFileSync(csvPath, formatExperimentCsv(results), "utf8");
+  fs.writeFileSync(
+    jsonPath,
+    JSON.stringify({ config: DEFAULT_BATCH_CONFIG, summary, results }, null, 2),
+    "utf8",
+  );
+
+  console.log(`✅ Reporte guardado en:\n  - ${csvPath}\n  - ${jsonPath}`);
+  console.log(`Corridas totales: ${summary.totalRuns}`);
+  for (const [key, stats] of Object.entries(summary.metrics)) {
+    console.log(`  • ${key}: ${stats.mean.toFixed(4)} ± ${stats.stdev.toFixed(4)}`);
+  }
+}
+
+main();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { exportGridPng } from "./utils/capture";
 import { LinePlot } from "./components/LinePlot";
 import { PhiCanvas, type Snapshot as PhiSnapshot } from "./components/PhiCanvas";
@@ -219,6 +219,14 @@ export default function App(){
   const [mu, setMu] = useState(0);
   const [kernel, setKernel] = useState<number[]>([0,-1,0,-1,5,-1,0,-1,0]);
 
+  const kernelIntensity = useMemo(() => {
+    if (!kernel.length) return 0;
+    const magnitude = kernel.reduce((sum, value) => sum + Math.abs(value), 0);
+    return magnitude / kernel.length;
+  }, [kernel]);
+  const muStructural = Math.min(0.5, kernelIntensity * 0.12);
+  const muEffective = Math.min(0.9, mu + muStructural);
+
   const [seeds, setSeeds] = useState<number[]>(() => Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
@@ -282,6 +290,8 @@ export default function App(){
             setBalance={setBalance}
             mu={mu}
             setMu={setMu}
+            muStructural={muStructural}
+            muEffective={muEffective}
           />
           <KernelEditor kernel={kernel} setKernel={setKernel} />
         </aside>
@@ -297,7 +307,7 @@ export default function App(){
                   grid={gridSize}
                   balance={balance}
                   kernel={kernel}
-                  mu={mu}
+                  mu={muEffective}
                   onToggle={()=> setRunning(prev => prev.map((v,idx)=> idx===i ? !v : v))}
                   onResetSoft={()=> setResetSignals(prev => prev.map((v,idx)=> idx===i ? v+1 : v))}
                   onResetHard={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? Math.floor(Math.random()*100000) : v))}
@@ -317,7 +327,7 @@ export default function App(){
                   grid={gridSize}
                   balance={balance}
                   kernel={kernel}
-                  mu={mu}
+                  mu={muEffective}
                   onToggle={()=> setRunning(prev => prev.map((v,idx)=> idx===i ? !v : v))}
                   onResetSoft={()=> setResetSignals(prev => prev.map((v,idx)=> idx===i ? v+1 : v))}
                   onResetHard={()=> setSeeds(prev => prev.map((v,idx)=> idx===i ? Math.floor(Math.random()*100000) : v))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,12 @@ export default function App(){
     URL.revokeObjectURL(url);
   };
 
+  const openExperimentsDoc = () => {
+    const experimentsUrl =
+      "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+    window.open(experimentsUrl, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 relative">
       <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
@@ -275,6 +281,7 @@ export default function App(){
           <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={resetAllHard}>Big Bang ♻︎</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={exportExcel}>Exportar CSV</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={()=>exportGridPng("grid")}>Exportar captura</button>
+          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={openExperimentsDoc}>Experimentos</button>
         </div>
       </header>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { GlobalParamsPanel } from "./components/GlobalParamsPanel";
 import { KernelEditor } from "./components/KernelEditor";
 import ReportPanel from "./ui/report";
 import { ResonanceMeter } from "./components/ResonanceMeter";
+import { Header } from "./ui/Header";
+import { ExperimentsPanel } from "./ui/ExperimentsPanel";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
@@ -231,6 +233,7 @@ export default function App(){
   const [seeds, setSeeds] = useState<number[]>(() => Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
+  const [showExperimentsPanel, setShowExperimentsPanel] = useState(false);
 
   useEffect(() => {
     setSeeds(Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
@@ -272,18 +275,22 @@ export default function App(){
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 relative">
-      <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
-        <h1 className="text-xl sm:text-2xl font-bold text-center sm:text-left">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
-        <div className="flex flex-wrap justify-center sm:justify-end gap-2">
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={startAll}>Iniciar todo</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={pauseAll}>Pausar todo</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={resetAllSoft}>Reset 𝓣/R</button>
-          <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={resetAllHard}>Big Bang ♻︎</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={exportExcel}>Exportar CSV</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={()=>exportGridPng("grid")}>Exportar captura</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={openExperimentsDoc}>Experimentos</button>
+      <Header
+        onStartAll={startAll}
+        onPauseAll={pauseAll}
+        onResetSoft={resetAllSoft}
+        onResetHard={resetAllHard}
+        onExportCsv={exportExcel}
+        onExportCapture={() => exportGridPng("grid")}
+        onToggleExperiments={() => setShowExperimentsPanel((prev) => !prev)}
+        experimentsOpen={showExperimentsPanel}
+      />
+
+      {showExperimentsPanel && (
+        <div className="mb-4">
+          <ExperimentsPanel onOpenDoc={openExperimentsDoc} />
         </div>
-      </header>
+      )}
 
       <div className="flex flex-col lg:flex-row gap-4">
         <aside className="space-y-4 w-full lg:w-2/5">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ReportPanel from "./ui/report";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 import { Header } from "./ui/Header";
 import { ExperimentsPanel } from "./ui/ExperimentsPanel";
+import { MetricsPanel } from "./ui/MetricsPanel";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
@@ -234,6 +235,7 @@ export default function App(){
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
   const [showExperimentsPanel, setShowExperimentsPanel] = useState(false);
+  const [showMetricsPanel, setShowMetricsPanel] = useState(false);
 
   useEffect(() => {
     setSeeds(Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
@@ -283,12 +285,15 @@ export default function App(){
         onExportCsv={exportExcel}
         onExportCapture={() => exportGridPng("grid")}
         onToggleExperiments={() => setShowExperimentsPanel((prev) => !prev)}
+        onToggleMetrics={() => setShowMetricsPanel((prev) => !prev)}
         experimentsOpen={showExperimentsPanel}
+        metricsOpen={showMetricsPanel}
       />
 
-      {showExperimentsPanel && (
-        <div className="mb-4">
-          <ExperimentsPanel onOpenDoc={openExperimentsDoc} />
+      {(showExperimentsPanel || showMetricsPanel) && (
+        <div className="space-y-4 mb-4">
+          {showMetricsPanel && <MetricsPanel seed={baseSeed} depth={gridSize} />}
+          {showExperimentsPanel && <ExperimentsPanel onOpenDoc={openExperimentsDoc} />}
         </div>
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { LinePlot } from "./components/LinePlot";
 import { PhiCanvas, type Snapshot as PhiSnapshot } from "./components/PhiCanvas";
 import { GlobalParamsPanel } from "./components/GlobalParamsPanel";
 import { KernelEditor } from "./components/KernelEditor";
+import ReportPanel from "./ui/report";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
@@ -294,6 +295,7 @@ export default function App(){
             muEffective={muEffective}
           />
           <KernelEditor kernel={kernel} setKernel={setKernel} />
+          <ReportPanel />
         </aside>
         <main className="w-full lg:w-3/5">
           <div id="grid">

--- a/src/components/GlobalParamsPanel.tsx
+++ b/src/components/GlobalParamsPanel.tsx
@@ -75,7 +75,7 @@ export function GlobalParamsPanel({
         <div className="text-xs mt-1">{balance.toFixed(2)}</div>
       </label>
       <label className="block text-sm">
-        Fricción μ
+        Fricción μ (solo sobre Φ)
         <input
           type="range"
           min={0}
@@ -85,7 +85,9 @@ export function GlobalParamsPanel({
           value={mu}
           onChange={(e) => setMu(parseFloat(e.target.value))}
         />
-        <div className="text-xs mt-1">{mu.toFixed(2)}</div>
+        <div className="text-xs mt-1">
+          {mu.toFixed(2)} — aplica únicamente a las características de las partículas Φ
+        </div>
         {typeof muStructural === "number" && (
           <div className="text-xs mt-1 text-slate-400">
             μ𝓛 ≈ {muStructural.toFixed(3)}

--- a/src/components/GlobalParamsPanel.tsx
+++ b/src/components/GlobalParamsPanel.tsx
@@ -11,6 +11,8 @@ export function GlobalParamsPanel({
   setBalance,
   mu,
   setMu,
+  muStructural,
+  muEffective,
 }: {
   seedBase: number;
   setSeedBase: (v: number) => void;
@@ -22,6 +24,8 @@ export function GlobalParamsPanel({
   setBalance: (v: number) => void;
   mu: number;
   setMu: (v: number) => void;
+  muStructural?: number;
+  muEffective?: number;
 }) {
   return (
     <div className="bg-slate-900/70 rounded-2xl p-4 space-y-4">
@@ -82,6 +86,16 @@ export function GlobalParamsPanel({
           onChange={(e) => setMu(parseFloat(e.target.value))}
         />
         <div className="text-xs mt-1">{mu.toFixed(2)}</div>
+        {typeof muStructural === "number" && (
+          <div className="text-xs mt-1 text-slate-400">
+            μ𝓛 ≈ {muStructural.toFixed(3)}
+          </div>
+        )}
+        {typeof muEffective === "number" && (
+          <div className="text-xs text-emerald-300">
+            μΣ ≈ {(muEffective).toFixed(3)}
+          </div>
+        )}
       </label>
     </div>
   );

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -5,6 +5,8 @@ type Props = {
   setL: (v: number[]) => void;
   theta: number;
   setTheta: (v: number) => void;
+  mu: number;
+  setMu: (v: number) => void;
   metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
   onResetMetrics?: () => void;
   alef?: { upperYud: number; vav: number; lowerYud: number; ratio: number };
@@ -12,7 +14,7 @@ type Props = {
   oneMetrics?: { entropy: number; density: number; clusters: number };
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onResetMetrics, alef, oneField, oneMetrics }: Props) {
+export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, metricsDelta, onResetMetrics, alef, oneField, oneMetrics }: Props) {
   const [showUnified, setShowUnified] = useState(false);
   const setIdx = (i: number, val: number) => {
     const next = [...L];
@@ -37,6 +39,11 @@ export function SensitivityPanel({ L, setL, theta, setTheta, metricsDelta, onRes
         <span>θ (umbral)</span>
         <input type="range" min={0} max={1} step={0.01} value={theta} onChange={e=>setTheta(parseFloat(e.target.value))} />
         <code>{theta.toFixed(2)}</code>
+      </div>
+      <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+        <span>μ (fricción)</span>
+        <input type="range" min={0} max={0.5} step={0.01} value={mu} onChange={e=>setMu(parseFloat(e.target.value))} />
+        <code>{mu.toFixed(2)}</code>
       </div>
       {!showUnified && (
         <>

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { HolographicControls } from "../ui/controls";
 
 type Props = {
   L: number[];
@@ -16,6 +17,14 @@ type Props = {
   alef?: { upperYud: number; vav: number; lowerYud: number; ratio: number };
   oneField?: number[];
   oneMetrics?: { entropy: number; density: number; clusters: number };
+  holographicMode?: boolean;
+  setHolographicMode?: (value: boolean) => void;
+  boundaryDepth?: number;
+  setBoundaryDepth?: (value: number) => void;
+  boundaryNoise?: number;
+  setBoundaryNoise?: (value: number) => void;
+  boundaryKernelMix?: number;
+  setBoundaryKernelMix?: (value: number) => void;
 };
 
 export function SensitivityPanel({
@@ -34,6 +43,14 @@ export function SensitivityPanel({
   alef,
   oneField,
   oneMetrics,
+  holographicMode,
+  setHolographicMode,
+  boundaryDepth,
+  setBoundaryDepth,
+  boundaryNoise,
+  setBoundaryNoise,
+  boundaryKernelMix,
+  setBoundaryKernelMix,
 }: Props) {
   const [showUnified, setShowUnified] = useState(false);
   const setIdx = (i: number, val: number) => {
@@ -162,6 +179,25 @@ export function SensitivityPanel({
       <button onClick={() => setShowUnified(v => !v)} style={{ justifySelf: "start", padding: "6px 10px" }}>
         {showUnified ? "Vista individual" : "Vista unificada"}
       </button>
+      {typeof holographicMode === "boolean" &&
+        setHolographicMode &&
+        typeof boundaryDepth === "number" &&
+        setBoundaryDepth &&
+        typeof boundaryNoise === "number" &&
+        setBoundaryNoise &&
+        typeof boundaryKernelMix === "number" &&
+        setBoundaryKernelMix && (
+          <HolographicControls
+            holographicMode={holographicMode}
+            setHolographicMode={setHolographicMode}
+            boundaryDepth={boundaryDepth}
+            setBoundaryDepth={setBoundaryDepth}
+            boundaryNoise={boundaryNoise}
+            setBoundaryNoise={setBoundaryNoise}
+            boundaryKernelMix={boundaryKernelMix}
+            setBoundaryKernelMix={setBoundaryKernelMix}
+          />
+        )}
     </div>
   );
 }

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -9,6 +9,8 @@ type Props = {
   setMu: (v: number) => void;
   muStructural?: number;
   muEffective?: number;
+  raGain?: number;
+  setRaGain?: (v: number) => void;
   metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
   onResetMetrics?: () => void;
   alef?: { upperYud: number; vav: number; lowerYud: number; ratio: number };
@@ -16,7 +18,23 @@ type Props = {
   oneMetrics?: { entropy: number; density: number; clusters: number };
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, muStructural, muEffective, metricsDelta, onResetMetrics, alef, oneField, oneMetrics }: Props) {
+export function SensitivityPanel({
+  L,
+  setL,
+  theta,
+  setTheta,
+  mu,
+  setMu,
+  muStructural,
+  muEffective,
+  raGain,
+  setRaGain,
+  metricsDelta,
+  onResetMetrics,
+  alef,
+  oneField,
+  oneMetrics,
+}: Props) {
   const [showUnified, setShowUnified] = useState(false);
   const setIdx = (i: number, val: number) => {
     const next = [...L];
@@ -24,63 +42,95 @@ export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, muStruct
     setL(next);
   };
   const slider = (label: string, i: number) => (
-    <div key={i} style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+    <div key={i} style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
       <span>{label}</span>
-      <input type="range" min={0} max={1} step={0.01} value={L[i]} onChange={e=>setIdx(i, parseFloat(e.target.value))} />
+      <input type="range" min={0} max={1} step={0.01} value={L[i]} onChange={e => setIdx(i, parseFloat(e.target.value))} />
       <code>{L[i].toFixed(2)}</code>
     </div>
   );
 
   return (
-    <div style={{border:"1px solid #444", borderRadius:8, padding:12, display:"grid", gap:10}}>
+    <div style={{ border: "1px solid #444", borderRadius: 8, padding: 12, display: "grid", gap: 10 }}>
       <strong>𝓛(x) y Umbral θ</strong>
       {slider("energy", 0)}
       {slider("symmetry", 1)}
       {slider("curvature", 2)}
-      <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+      <div style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
         <span>θ (umbral)</span>
-        <input type="range" min={0} max={1} step={0.01} value={theta} onChange={e=>setTheta(parseFloat(e.target.value))} />
+        <input type="range" min={0} max={1} step={0.01} value={theta} onChange={e => setTheta(parseFloat(e.target.value))} />
         <code>{theta.toFixed(2)}</code>
       </div>
-      <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+      <div style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
         <span>μ₀ (base)</span>
-        <input type="range" min={0} max={0.5} step={0.01} value={mu} onChange={e=>setMu(parseFloat(e.target.value))} />
+        <input type="range" min={0} max={0.5} step={0.01} value={mu} onChange={e => setMu(parseFloat(e.target.value))} />
         <code>{mu.toFixed(2)}</code>
       </div>
+      {typeof raGain === "number" && setRaGain && (
+        <div style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
+          <span>𝓡ₐ (retro)</span>
+          <input type="range" min={0} max={0.5} step={0.01} value={raGain} onChange={e => setRaGain(parseFloat(e.target.value))} />
+          <code>{raGain.toFixed(2)}</code>
+        </div>
+      )}
       {typeof muStructural === "number" && (
-        <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+        <div style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
           <span>μ𝓛 (estructura)</span>
-          <div style={{height:4, background:"#333", position:"relative", borderRadius:2}}>
-            <div style={{position:"absolute", left:0, top:0, bottom:0, width:`${Math.min(1, muStructural / 0.5) * 100}%`, background:"#7dd3fc", borderRadius:2}} />
+          <div style={{ height: 4, background: "#333", position: "relative", borderRadius: 2 }}>
+            <div
+              style={{
+                position: "absolute",
+                left: 0,
+                top: 0,
+                bottom: 0,
+                width: `${Math.min(1, muStructural / 0.5) * 100}%`,
+                background: "#7dd3fc",
+                borderRadius: 2,
+              }}
+            />
           </div>
           <code>{muStructural.toFixed(2)}</code>
         </div>
       )}
       {typeof muEffective === "number" && (
-        <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+        <div style={{ display: "grid", gridTemplateColumns: "90px 1fr 60px", gap: 8, alignItems: "center" }}>
           <span>μΣ (total)</span>
-          <div style={{height:4, background:"#333", position:"relative", borderRadius:2}}>
-            <div style={{position:"absolute", left:0, top:0, bottom:0, width:`${Math.min(1, muEffective / 0.95) * 100}%`, background:"#34d399", borderRadius:2}} />
+          <div style={{ height: 4, background: "#333", position: "relative", borderRadius: 2 }}>
+            <div
+              style={{
+                position: "absolute",
+                left: 0,
+                top: 0,
+                bottom: 0,
+                width: `${Math.min(1, muEffective / 0.95) * 100}%`,
+                background: "#34d399",
+                borderRadius: 2,
+              }}
+            />
           </div>
           <code>{muEffective.toFixed(2)}</code>
         </div>
       )}
-      <small style={{color:"#aaa"}}>La fricción total surge de μ₀ más la resistencia estructural de 𝓛; solo Φ se atenúa.</small>
+      <small style={{ color: "#aaa" }}>
+        La fricción total surge de μ₀ más la resistencia estructural de 𝓛; solo Φ se atenúa. Con 𝓡ₐ activada, los eventos y las
+        variaciones de R reajustan gradualmente la lattice.
+      </small>
       {!showUnified && (
         <>
-          <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8}}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 8 }}>
             <MiniStat label="Δ Entropía" value={metricsDelta.dEntropy} />
             <MiniStat label="Δ Densidad" value={metricsDelta.dDensity} />
             <MiniStat label="Δ Clusters" value={metricsDelta.dClusters} />
           </div>
-          <button onClick={onResetMetrics} style={{justifySelf:"start", padding:"6px 10px"}}>Reiniciar Δ</button>
+          <button onClick={onResetMetrics} style={{ justifySelf: "start", padding: "6px 10px" }}>
+            Reiniciar Δ
+          </button>
           {alef && (
             <div
               style={{
-                display:"grid",
-                gridTemplateColumns:"repeat(4,1fr)",
-                gap:8,
-                marginTop:8
+                display: "grid",
+                gridTemplateColumns: "repeat(4,1fr)",
+                gap: 8,
+                marginTop: 8,
               }}
             >
               <MiniStat label="Ω (Yud)" value={alef.upperYud} />
@@ -93,12 +143,12 @@ export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, muStruct
       )}
       {showUnified && oneField && oneMetrics && (
         <>
-          <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8}}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 8 }}>
             <MiniStat label="Entropía(U)" value={oneMetrics.entropy} />
             <MiniStat label="Densidad(U)" value={oneMetrics.density} />
             <MiniStat label="Clusters(U)" value={oneMetrics.clusters} />
           </div>
-          <div style={{display:"grid", gridTemplateColumns:"repeat(7,1fr)", gap:8, marginTop:8}}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(7,1fr)", gap: 8, marginTop: 8 }}>
             <MiniStat label="Φ̅" value={oneField[0]} />
             <MiniStat label="L1" value={oneField[1]} />
             <MiniStat label="L2" value={oneField[2]} />
@@ -109,19 +159,19 @@ export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, muStruct
           </div>
         </>
       )}
-      <button onClick={()=>setShowUnified(v=>!v)} style={{justifySelf:"start", padding:"6px 10px"}}>
+      <button onClick={() => setShowUnified(v => !v)} style={{ justifySelf: "start", padding: "6px 10px" }}>
         {showUnified ? "Vista individual" : "Vista unificada"}
       </button>
     </div>
   );
 }
 
-function MiniStat({ label, value }: {label:string; value:number}) {
+function MiniStat({ label, value }: { label: string; value: number }) {
   const color = value > 0 ? "#6f6" : value < 0 ? "#f66" : "#ccc";
   return (
-    <div style={{border:"1px solid #333", borderRadius:6, padding:8}}>
-      <div style={{fontSize:12, color:"#aaa"}}>{label}</div>
-      <div style={{fontWeight:700, color}}>{value.toFixed(3)}</div>
+    <div style={{ border: "1px solid #333", borderRadius: 6, padding: 8 }}>
+      <div style={{ fontSize: 12, color: "#aaa" }}>{label}</div>
+      <div style={{ fontWeight: 700, color }}>{value.toFixed(3)}</div>
     </div>
   );
 }

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -7,6 +7,8 @@ type Props = {
   setTheta: (v: number) => void;
   mu: number;
   setMu: (v: number) => void;
+  muStructural?: number;
+  muEffective?: number;
   metricsDelta: { dEntropy: number; dDensity: number; dClusters: number };
   onResetMetrics?: () => void;
   alef?: { upperYud: number; vav: number; lowerYud: number; ratio: number };
@@ -14,7 +16,7 @@ type Props = {
   oneMetrics?: { entropy: number; density: number; clusters: number };
 };
 
-export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, metricsDelta, onResetMetrics, alef, oneField, oneMetrics }: Props) {
+export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, muStructural, muEffective, metricsDelta, onResetMetrics, alef, oneField, oneMetrics }: Props) {
   const [showUnified, setShowUnified] = useState(false);
   const setIdx = (i: number, val: number) => {
     const next = [...L];
@@ -41,11 +43,29 @@ export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, metricsD
         <code>{theta.toFixed(2)}</code>
       </div>
       <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
-        <span>μ (fricción)</span>
+        <span>μ₀ (base)</span>
         <input type="range" min={0} max={0.5} step={0.01} value={mu} onChange={e=>setMu(parseFloat(e.target.value))} />
         <code>{mu.toFixed(2)}</code>
       </div>
-      <small style={{color:"#aaa"}}>Atenúa Φ en cada tic; 𝓛 permanece fija.</small>
+      {typeof muStructural === "number" && (
+        <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+          <span>μ𝓛 (estructura)</span>
+          <div style={{height:4, background:"#333", position:"relative", borderRadius:2}}>
+            <div style={{position:"absolute", left:0, top:0, bottom:0, width:`${Math.min(1, muStructural / 0.5) * 100}%`, background:"#7dd3fc", borderRadius:2}} />
+          </div>
+          <code>{muStructural.toFixed(2)}</code>
+        </div>
+      )}
+      {typeof muEffective === "number" && (
+        <div style={{display:"grid", gridTemplateColumns:"90px 1fr 60px", gap:8, alignItems:"center"}}>
+          <span>μΣ (total)</span>
+          <div style={{height:4, background:"#333", position:"relative", borderRadius:2}}>
+            <div style={{position:"absolute", left:0, top:0, bottom:0, width:`${Math.min(1, muEffective / 0.95) * 100}%`, background:"#34d399", borderRadius:2}} />
+          </div>
+          <code>{muEffective.toFixed(2)}</code>
+        </div>
+      )}
+      <small style={{color:"#aaa"}}>La fricción total surge de μ₀ más la resistencia estructural de 𝓛; solo Φ se atenúa.</small>
       {!showUnified && (
         <>
           <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8}}>

--- a/src/components/SensitivityPanel.tsx
+++ b/src/components/SensitivityPanel.tsx
@@ -45,6 +45,7 @@ export function SensitivityPanel({ L, setL, theta, setTheta, mu, setMu, metricsD
         <input type="range" min={0} max={0.5} step={0.01} value={mu} onChange={e=>setMu(parseFloat(e.target.value))} />
         <code>{mu.toFixed(2)}</code>
       </div>
+      <small style={{color:"#aaa"}}>Atenúa Φ en cada tic; 𝓛 permanece fija.</small>
       {!showUnified && (
         <>
           <div style={{display:"grid", gridTemplateColumns:"repeat(3,1fr)", gap:8}}>

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,3 +1,5 @@
+import { computeAreaLaw } from "./metrics.ts";
+
 // BigBang_PLUS engine — maps UI concepts to SOLIS axioms
 // Ω: not modeled
 // Φ: stochastic potential field derived from seed
@@ -285,6 +287,12 @@ export function tick(state){
     for(let i=0;i<state.shaped.length;i++){
       state.shaped[i] *= (1 - mu);
     }
+  }
+
+  if (state.shaped && state.shaped.length === grid * grid) {
+    state.areaLaw = computeAreaLaw(state.shaped, grid);
+  } else {
+    state.areaLaw = state.areaLaw ?? null;
   }
   // Axioma XI: R como cociente Ω/(Φ∘𝓛)
   let phiL = 0;

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,0 +1,278 @@
+import { computeAreaLaw } from "../metrics";
+import { measureEntropyForces } from "../perturb";
+import {
+  captureSample,
+  evaluateReconstruction,
+  trainDecoder,
+  type MaskOptions,
+} from "../reconstruction";
+import { cosineSim01 } from "./resonance";
+import { computeHolographicBulk } from "./solisModel";
+
+export type ExperimentConfig = {
+  depths?: number[];
+  boundaryNoises?: number[];
+  kernelMixes?: number[];
+  seeds?: number[];
+  particleCount?: number;
+  dims?: number;
+  coverage?: number;
+  maskOffset?: number;
+  maskMode?: MaskOptions["mode"];
+};
+
+export type ExperimentResult = {
+  depth: number;
+  boundaryNoise: number;
+  kernelMix: number;
+  seed: number;
+  r2Perimeter: number;
+  r2Area: number;
+  resonanceMean: number;
+  resonanceVariance: number;
+  reconstructionMse: number;
+  reconstructionMseInterior: number;
+  reconstructionPsnr: number;
+  flowMeanMagnitude: number;
+  flowMeanAlignment: number;
+  flowStdAlignment: number;
+  flowDominantMagnitude: number;
+  flowDominantAlignment: number;
+  flowCount: number;
+};
+
+export type ExperimentSummary = {
+  totalRuns: number;
+  metrics: Record<string, { mean: number; stdev: number }>;
+};
+
+export const DEFAULT_BATCH_CONFIG: Required<Pick<ExperimentConfig,
+  "depths" | "boundaryNoises" | "kernelMixes" | "seeds" | "particleCount" | "dims" | "coverage" | "maskOffset" | "maskMode">
+> = {
+  depths: [2, 4, 6],
+  boundaryNoises: [0, 0.1, 0.2],
+  kernelMixes: [0, 0.5, 1],
+  seeds: [11, 23, 37, 53],
+  particleCount: 96,
+  dims: 3,
+  coverage: 0.65,
+  maskOffset: 0.2,
+  maskMode: "contiguous",
+};
+
+const SUMMARY_KEYS: Array<{ key: keyof ExperimentResult; label: string }> = [
+  { key: "r2Perimeter", label: "R²_perímetro" },
+  { key: "r2Area", label: "R²_área" },
+  { key: "reconstructionMse", label: "MSE reconstrucción" },
+  { key: "resonanceVariance", label: "Var(ℜ)" },
+  { key: "flowMeanMagnitude", label: "‖flujo‖ medio" },
+  { key: "flowMeanAlignment", label: "Alineación media" },
+];
+
+function seededRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0xffffffff;
+  };
+}
+
+function buildLatticeFromSeed(seed: number, dims: number): number[] {
+  const rand = seededRandom(seed);
+  const values = Array.from({ length: dims }, () => rand());
+  const sum = values.reduce((acc, v) => acc + v, 0) || 1;
+  return values.map((v) => v / sum);
+}
+
+function generateParticles(seed: number, count: number, dims: number) {
+  const rand = seededRandom(seed * 97 + 13);
+  return Array.from({ length: count }, (_, idx) => ({
+    id: `p-${seed}-${idx}`,
+    features: Array.from({ length: dims }, () => rand()),
+  }));
+}
+
+function computeResonances(
+  particles: { features: number[] }[],
+  lattice: number[],
+) {
+  const values = particles.map((p) => cosineSim01(p.features, lattice));
+  const mean = values.length
+    ? values.reduce((acc, v) => acc + v, 0) / values.length
+    : 0;
+  const variance = values.length
+    ? values.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) / values.length
+    : 0;
+  return { values, mean, variance };
+}
+
+function stats(values: number[]): { mean: number; stdev: number } {
+  if (!values.length) {
+    return { mean: 0, stdev: 0 };
+  }
+  const mean = values.reduce((acc, v) => acc + v, 0) / values.length;
+  if (values.length === 1) {
+    return { mean, stdev: 0 };
+  }
+  const variance = values.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) / (values.length - 1);
+  return { mean, stdev: Math.sqrt(Math.max(variance, 0)) };
+}
+
+function aggregateSummary(results: ExperimentResult[]): ExperimentSummary {
+  const metrics: Record<string, { mean: number; stdev: number }> = {};
+  for (const item of SUMMARY_KEYS) {
+    const values = results.map((res) => res[item.key] as number);
+    metrics[item.key] = stats(values);
+  }
+  return { totalRuns: results.length, metrics };
+}
+
+function clamp01(value: number) {
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+export function runBatchExperiments(config: ExperimentConfig = {}) {
+  const {
+    depths,
+    boundaryNoises,
+    kernelMixes,
+    seeds,
+    particleCount,
+    dims,
+    coverage,
+    maskOffset,
+    maskMode,
+  } = {
+    ...DEFAULT_BATCH_CONFIG,
+    ...config,
+  };
+
+  const results: ExperimentResult[] = [];
+
+  for (const depth of depths) {
+    for (const boundaryNoise of boundaryNoises) {
+      for (const kernelMix of kernelMixes) {
+        for (const seed of seeds) {
+          const lattice = buildLatticeFromSeed(seed, dims);
+          const holo = computeHolographicBulk(
+            lattice,
+            particleCount,
+            depth,
+            boundaryNoise,
+            kernelMix,
+          );
+          const grid = holo.grid || 1;
+          const field = holo.field[0] ?? new Float32Array(grid * grid);
+          const areaLaw = computeAreaLaw(field, grid);
+
+          const sample = captureSample(field, grid);
+          const model = trainDecoder([sample], { type: "linear", includeBias: true, ridge: 1e-3, l2: 1e-5 });
+          const evaluation = evaluateReconstruction(sample, model, {
+            coverage,
+            mode: maskMode,
+            offset: maskOffset,
+          });
+
+          const particles = generateParticles(seed, particleCount, dims);
+          const { mean: resonanceMean, variance: resonanceVariance } = computeResonances(
+            particles,
+            lattice,
+          );
+
+          const flows = measureEntropyForces(field, grid, { arcLength: Math.max(6, Math.floor(grid / 8)) });
+          const flowCount = flows.length;
+          const flowMeanMagnitude = flowCount
+            ? flows.reduce((acc, item) => acc + item.flow.magnitude, 0) / flowCount
+            : 0;
+          const flowMeanAlignment = flowCount
+            ? flows.reduce((acc, item) => acc + item.flow.alignment, 0) / flowCount
+            : 0;
+          const flowStdAlignment = flowCount
+            ? Math.sqrt(
+                flows.reduce((acc, item) => acc + Math.pow(item.flow.alignment - flowMeanAlignment, 2), 0) /
+                  flowCount,
+              )
+            : 0;
+          const dominant = flows.reduce((best, current) => {
+            if (!best) return current;
+            return current.flow.magnitude > best.flow.magnitude ? current : best;
+          }, flows[0] ?? null);
+
+          results.push({
+            depth,
+            boundaryNoise,
+            kernelMix,
+            seed,
+            r2Perimeter: areaLaw?.perimeterFit.r2 ?? 0,
+            r2Area: areaLaw?.areaFit.r2 ?? 0,
+            resonanceMean,
+            resonanceVariance,
+            reconstructionMse: evaluation.metrics.mse,
+            reconstructionMseInterior: evaluation.metrics.mseInterior,
+            reconstructionPsnr: evaluation.metrics.psnr,
+            flowMeanMagnitude,
+            flowMeanAlignment,
+            flowStdAlignment,
+            flowDominantMagnitude: dominant?.flow.magnitude ?? 0,
+            flowDominantAlignment: dominant?.flow.alignment ?? 0,
+            flowCount,
+          });
+        }
+      }
+    }
+  }
+
+  const summary = aggregateSummary(results);
+  return { results, summary };
+}
+
+export function formatExperimentCsv(results: ExperimentResult[]): string {
+  const header = [
+    "depth",
+    "boundaryNoise",
+    "kernelMix",
+    "seed",
+    "r2_perimeter",
+    "r2_area",
+    "resonance_mean",
+    "resonance_variance",
+    "mse",
+    "mse_interior",
+    "psnr",
+    "flow_mean_magnitude",
+    "flow_mean_alignment",
+    "flow_std_alignment",
+    "flow_dominant_magnitude",
+    "flow_dominant_alignment",
+    "flow_count",
+  ];
+  const rows = results.map((res) => [
+    res.depth,
+    res.boundaryNoise,
+    res.kernelMix,
+    res.seed,
+    res.r2Perimeter,
+    res.r2Area,
+    res.resonanceMean,
+    res.resonanceVariance,
+    res.reconstructionMse,
+    res.reconstructionMseInterior,
+    res.reconstructionPsnr,
+    res.flowMeanMagnitude,
+    res.flowMeanAlignment,
+    res.flowStdAlignment,
+    res.flowDominantMagnitude,
+    res.flowDominantAlignment,
+    res.flowCount,
+  ].map((value) => {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value.toString() : "";
+    }
+    return value;
+  }));
+  return [header.join(","), ...rows.map((row) => row.join(","))].join("\n");
+}
+
+export const REPORT_SUMMARY_KEYS = SUMMARY_KEYS;

--- a/src/lib/resonance.ts
+++ b/src/lib/resonance.ts
@@ -56,19 +56,43 @@ export function countClusters1D(values: number[]): number {
   if (values.length < 2) return values.length;
   let centers = [0.2, 0.5, 0.8];
   for (let iter = 0; iter < 5; iter++) {
-    const groups: number[][] = [[], [], []];
+    const groups: number[][] = centers.map(() => []);
     for (const v of values) {
       let best = 0, bestd = Infinity;
       for (let i = 0; i < centers.length; i++) {
         const d = Math.abs(v - centers[i]);
-        if (d < bestd) { bestd = d; best = i; }
+        if (d < bestd) {
+          bestd = d;
+          best = i;
+        }
       }
       groups[best].push(v);
     }
-    centers = groups.map(g => g.length ? g.reduce((a,b)=>a+b,0)/g.length : Math.random());
+    centers = groups
+      .filter((g) => g.length)
+      .map((g) => g.reduce((a, b) => a + b, 0) / g.length);
   }
-  return centers.length;
+  // asignación final para contar grupos no vacíos
+  const finalGroups: number[][] = centers.map(() => []);
+  for (const v of values) {
+    let best = 0, bestd = Infinity;
+    for (let i = 0; i < centers.length; i++) {
+      const d = Math.abs(v - centers[i]);
+      if (d < bestd) {
+        bestd = d;
+        best = i;
+      }
+    }
+    finalGroups[best].push(v);
+  }
+  return finalGroups.filter((g) => g.length > 0).length;
 }
+
+/*
+Ejemplo rápido de uso:
+countClusters1D([0.1, 0.15, 0.8]) → 2
+countClusters1D([0.1, 0.15, 0.2]) → 1
+*/
 
 export function computeMetrics(resonances: number[], theta: number): Metrics {
   const entropy = approxEntropy(resonances);

--- a/src/lib/solisModel.ts
+++ b/src/lib/solisModel.ts
@@ -53,12 +53,12 @@ function arraysClose(a: number[], b: number[]) {
   return true;
 }
 
-const DEFAULT_DEPTH_DECAY = 0.85;
+export const DEFAULT_DEPTH_DECAY = 0.85;
 const HAMMING_ALPHA = 0.54;
 const HAMMING_BETA = 0.46;
 const HAMMING_WINDOW = 64;
 
-function buildDepthWeights(length: number, boundaryDepth: number, depthDecay: number) {
+export function buildDepthWeights(length: number, boundaryDepth: number, depthDecay: number) {
   if (length <= 0) return [];
   const limit = Math.max(0, Math.floor(boundaryDepth));
   const decay = clamp01(depthDecay);
@@ -115,7 +115,7 @@ type HolographicResult = {
   grid: number;
 };
 
-function computeHolographicBulk(
+export function computeHolographicBulk(
   boundaryValues: number[],
   particleCount: number,
   depth: number,

--- a/src/lib/solisModel.ts
+++ b/src/lib/solisModel.ts
@@ -8,11 +8,11 @@ export type EventEpsilon = {
   L: number[]; // snapshot
 };
 
-export function useSolisModel() {
+export function useSolisModel(initialMu = 0) {
   // 𝓛(x): pesos/operador (3 dimensiones por defecto)
   const [L, setL] = useState<number[]>([0.6, 0.3, 0.1]);
   // μ₀: fricción ontológica base (Axioma IX)
-  const [mu, setMu] = useState<number>(0);
+  const [mu, setMu] = useState<number>(initialMu);
   // θ: umbral de evento
   const [theta, setTheta] = useState<number>(0.8);
   // resonancia actual promedio (para el medidor)
@@ -97,7 +97,7 @@ export function useSolisModel() {
     const unified = [phiMean, ...LNow, avg, epsVal, reality];
     setOneField(unified);
     setOneMetrics(computeMetrics(unified, theta));
-  }, [L, theta, muEffective]);
+  }, [L, theta, mu, muEffective]);
 
   const resetMetrics = useCallback(() => {
     lastMetricsRef.current = { entropy: 0, density: 0, clusters: 0 };

--- a/src/lib/solisModel.ts
+++ b/src/lib/solisModel.ts
@@ -41,7 +41,7 @@ export function useSolisModel() {
     timeRef.current += 1;
     let P = particlesRef.current;
 
-    // Axioma IX: la fricción μ atenúa Φ y 𝓛
+    // Axioma IX: la fricción μ atenúa únicamente Φ (partículas)
     if (mu > 0) {
       P = P.map(p => ({
         ...p,
@@ -49,8 +49,7 @@ export function useSolisModel() {
       }));
       particlesRef.current = P;
     }
-    const LNow = mu > 0 ? L.map(v => v * (1 - mu)) : L;
-    if (mu > 0) setL(LNow);
+    const LNow = L;
 
     const res = P.map(p => cosineSim01(p.features, LNow));
     const avg = res.length ? res.reduce((a,b)=>a+b,0)/res.length : 0;

--- a/src/lib/solisModel.ts
+++ b/src/lib/solisModel.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
+import { computeAreaLaw, type AreaLawMetrics } from "../metrics";
 import { Particle, cosineSim01, computeMetrics } from "./resonance";
 
 const SMOOTH_KERNEL = [
@@ -244,6 +245,7 @@ export function useSolisModel(initialMu = 0) {
   // Axioma XIII: vector unificado que muestra que todo proviene del mismo fondo
   const [oneField, setOneField] = useState<number[]>([]);
   const [oneMetrics, setOneMetrics] = useState({ entropy: 0, density: 0, clusters: 0 });
+  const [areaLawMetrics, setAreaLawMetrics] = useState<AreaLawMetrics | null>(null);
   // 𝓡ₐ: intensidad de retroalimentación de R sobre 𝓛
   const [raGain, setRaGain] = useState<number>(0);
   // modo holográfico
@@ -293,12 +295,19 @@ export function useSolisModel(initialMu = 0) {
       setHolographicBulk(prev => (arraysClose(prev, holo.bulk) ? prev : [...holo.bulk]));
       holographicFieldRef.current = holo.field;
       setHolographicGrid(prev => (prev === holo.grid ? prev : holo.grid));
+      if (holo.field?.length && holo.grid > 0) {
+        const referenceField = holo.field[0];
+        setAreaLawMetrics(computeAreaLaw(referenceField, holo.grid));
+      } else {
+        setAreaLawMetrics(null);
+      }
     } else {
       setHolographicBulk(prev => (arraysClose(prev, L) ? prev : [...L]));
       if (holographicFieldRef.current !== null) {
         holographicFieldRef.current = null;
       }
       setHolographicGrid(prev => (prev === 0 ? prev : 0));
+      setAreaLawMetrics(null);
     }
 
     const res = P.map(p => cosineSim01(p.features, LNow));
@@ -412,6 +421,7 @@ export function useSolisModel(initialMu = 0) {
     holographicBulk,
     holographicField: holographicFieldRef.current,
     holographicGrid,
+    areaLawMetrics,
     pushParticles, tick
   };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,7 @@ function makeState({seed, grid, preset, mu, dimPhi, dimOmega}){
     customKernel: customKernel.slice(),
     realityRatio: 0,
     metaSpace: { dimPhi, dimOmega },
+    areaLaw: null,
     // Timeline buffers
     timeline: [], // array of snapshots
     resSeries: [],

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -166,9 +166,10 @@ export function sampleBoundaryEntropy(
   if (count === 0) {
     return [];
   }
+  const defaultArc = Math.floor(count / 12) || 3;
   const effectiveArc = Math.min(
     count,
-    Math.max(3, arcLength ?? Math.floor(count / 12) || 3),
+    Math.max(3, arcLength ?? defaultArc),
   );
   const stride = Math.max(1, Math.floor(effectiveArc / 2));
   const arcs: BoundaryEntropyArc[] = [];

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,182 @@
+export type AreaLawRegion = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  area: number;
+  perimeter: number;
+  entropy: number;
+};
+
+export type RegressionResult = {
+  slope: number;
+  intercept: number;
+  r2: number;
+};
+
+export type AreaLawMetrics = {
+  regions: AreaLawRegion[];
+  perimeterFit: RegressionResult;
+  areaFit: RegressionResult;
+};
+
+function shannonEntropy(values: number[]): number {
+  let total = 0;
+  for (const value of values) {
+    const positive = value > 0 ? value : 0;
+    total += positive;
+  }
+  if (!isFinite(total) || total <= 0) {
+    return 0;
+  }
+  let entropy = 0;
+  for (const value of values) {
+    const positive = value > 0 ? value : 0;
+    if (positive <= 0) continue;
+    const p = positive / total;
+    entropy -= p * Math.log(p);
+  }
+  return entropy;
+}
+
+function linearRegression(xs: number[], ys: number[]): RegressionResult {
+  const n = Math.min(xs.length, ys.length);
+  if (n === 0) {
+    return { slope: 0, intercept: 0, r2: 0 };
+  }
+  let sumX = 0;
+  let sumY = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += xs[i];
+    sumY += ys[i];
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+
+  let covXY = 0;
+  let varX = 0;
+  let ssTot = 0;
+
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - meanX;
+    const dy = ys[i] - meanY;
+    covXY += dx * dy;
+    varX += dx * dx;
+    ssTot += dy * dy;
+  }
+
+  const slope = varX > 0 ? covXY / varX : 0;
+  const intercept = meanY - slope * meanX;
+
+  if (ssTot === 0) {
+    return { slope, intercept, r2: 1 };
+  }
+
+  let ssRes = 0;
+  for (let i = 0; i < n; i++) {
+    const predicted = slope * xs[i] + intercept;
+    const diff = ys[i] - predicted;
+    ssRes += diff * diff;
+  }
+
+  const r2 = 1 - ssRes / ssTot;
+  return { slope, intercept, r2: Number.isFinite(r2) ? r2 : 0 };
+}
+
+function collectRegionValues(
+  field: ArrayLike<number>,
+  grid: number,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): number[] {
+  const values: number[] = [];
+  for (let yy = y; yy < y + height; yy++) {
+    for (let xx = x; xx < x + width; xx++) {
+      const clampedX = Math.max(0, Math.min(grid - 1, xx));
+      const clampedY = Math.max(0, Math.min(grid - 1, yy));
+      values.push(field[clampedY * grid + clampedX] ?? 0);
+    }
+  }
+  return values;
+}
+
+function buildSampleSizes(grid: number): number[] {
+  const base = Math.max(4, Math.floor(grid / 6));
+  const sizes = new Set<number>();
+  for (let step = base; step <= grid; step += base) {
+    sizes.add(Math.max(3, Math.min(grid, step)));
+  }
+  sizes.add(grid);
+  sizes.add(Math.max(3, Math.floor(grid / 2)));
+  sizes.add(Math.max(3, Math.floor(grid / 3)));
+  sizes.add(Math.max(3, Math.floor(grid / 4)));
+  return Array.from(sizes).filter((size) => size >= 3 && size <= grid).sort((a, b) => a - b);
+}
+
+export function computeAreaLaw(
+  field: ArrayLike<number>,
+  grid: number,
+  sampleLimit = 128,
+): AreaLawMetrics {
+  if (!Number.isFinite(grid) || grid <= 0) {
+    return {
+      regions: [],
+      perimeterFit: { slope: 0, intercept: 0, r2: 0 },
+      areaFit: { slope: 0, intercept: 0, r2: 0 },
+    };
+  }
+
+  const sizes = buildSampleSizes(grid);
+  const regions: AreaLawRegion[] = [];
+
+  for (const width of sizes) {
+    for (const height of sizes) {
+      if (width > grid || height > grid) continue;
+      const strideX = Math.max(1, Math.floor(width / 2));
+      const strideY = Math.max(1, Math.floor(height / 2));
+      for (let y = 0; y <= grid - height; y += strideY) {
+        for (let x = 0; x <= grid - width; x += strideX) {
+          const values = collectRegionValues(field, grid, x, y, width, height);
+          const entropy = shannonEntropy(values);
+          regions.push({
+            x,
+            y,
+            width,
+            height,
+            area: width * height,
+            perimeter: 2 * (width + height),
+            entropy,
+          });
+          if (regions.length >= sampleLimit) break;
+        }
+        if (regions.length >= sampleLimit) break;
+      }
+      if (regions.length >= sampleLimit) break;
+    }
+    if (regions.length >= sampleLimit) break;
+  }
+
+  if (regions.length === 0) {
+    return {
+      regions,
+      perimeterFit: { slope: 0, intercept: 0, r2: 0 },
+      areaFit: { slope: 0, intercept: 0, r2: 0 },
+    };
+  }
+
+  const perimeters = regions.map((r) => r.perimeter);
+  const areas = regions.map((r) => r.area);
+  const entropies = regions.map((r) => r.entropy);
+
+  const perimeterFit = linearRegression(perimeters, entropies);
+  const areaFit = linearRegression(areas, entropies);
+
+  return {
+    regions,
+    perimeterFit,
+    areaFit,
+  };
+}
+

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -264,3 +264,15 @@ export function computeAreaLaw(
   };
 }
 
+
+export function getR2Perimeter(): number | null {
+  return null;
+}
+
+export function getR2Area(): number | null {
+  return null;
+}
+
+export function getBoundaryMode(): boolean | null {
+  return null;
+}

--- a/src/perturb.ts
+++ b/src/perturb.ts
@@ -1,0 +1,205 @@
+import { sampleBoundaryEntropy, type BoundaryEntropyArc } from "./metrics";
+
+export type EntropyForceOptions = {
+  arcLength?: number;
+  delta?: number;
+  iterations?: number;
+  diffusionRate?: number;
+};
+
+export type EntropyForceVector = {
+  x: number;
+  y: number;
+  magnitude: number;
+  alignment: number;
+};
+
+export type EntropyForceResult = {
+  arc: BoundaryEntropyArc;
+  flow: EntropyForceVector;
+  totalDelta: number;
+};
+
+const DEFAULT_DELTA = 0.12;
+const DEFAULT_ITERATIONS = 6;
+const DEFAULT_DIFFUSION = 0.35;
+
+function clampFinite(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value > 1e6) return 1e6;
+  if (value < -1e6) return -1e6;
+  return value;
+}
+
+function buildBoundaryMask(grid: number): Uint8Array {
+  const total = grid * grid;
+  const mask = new Uint8Array(total);
+  if (grid <= 1) {
+    for (let i = 0; i < total; i++) mask[i] = 1;
+    return mask;
+  }
+  const limit = grid - 1;
+  for (let x = 0; x < grid; x++) {
+    mask[x] = 1;
+    mask[limit * grid + x] = 1;
+  }
+  for (let y = 0; y < grid; y++) {
+    mask[y * grid] = 1;
+    mask[y * grid + limit] = 1;
+  }
+  return mask;
+}
+
+function runDiffusion(
+  initial: Float32Array,
+  grid: number,
+  boundaryMask: Uint8Array,
+  iterations: number,
+  rate: number,
+): Float32Array {
+  const total = grid * grid;
+  let current = Float32Array.from(initial);
+  let buffer = new Float32Array(total);
+  const clampRate = Math.max(0.01, Math.min(1, rate));
+  for (let iter = 0; iter < iterations; iter++) {
+    for (let y = 0; y < grid; y++) {
+      for (let x = 0; x < grid; x++) {
+        const id = y * grid + x;
+        if (boundaryMask[id]) {
+          buffer[id] = current[id];
+          continue;
+        }
+        let sum = 0;
+        let count = 0;
+        if (x > 0) {
+          sum += current[id - 1];
+          count++;
+        }
+        if (x + 1 < grid) {
+          sum += current[id + 1];
+          count++;
+        }
+        if (y > 0) {
+          sum += current[id - grid];
+          count++;
+        }
+        if (y + 1 < grid) {
+          sum += current[id + grid];
+          count++;
+        }
+        const avg = count > 0 ? sum / count : current[id];
+        buffer[id] = current[id] + clampRate * (avg - current[id]);
+      }
+    }
+    const next = buffer;
+    buffer = current;
+    current = next;
+  }
+  return current;
+}
+
+function applyArcPerturbation(
+  base: Float32Array,
+  arc: BoundaryEntropyArc,
+  delta: number,
+): Float32Array {
+  const perturbed = Float32Array.from(base);
+  const length = arc.indices.length || 1;
+  for (let i = 0; i < length; i++) {
+    const idx = arc.indices[i];
+    const seed = Math.sin((idx + 1) * 12.9898 + (i + 1) * 78.233);
+    const jitter = (seed - Math.floor(seed)) * 2 - 1;
+    perturbed[idx] = clampFinite(perturbed[idx] + delta * jitter);
+  }
+  return perturbed;
+}
+
+function computeFlowVector(
+  baseline: Float32Array,
+  perturbed: Float32Array,
+  grid: number,
+  arc: BoundaryEntropyArc,
+): { flow: EntropyForceVector; totalDelta: number } {
+  const centerX = arc.centerX;
+  const centerY = arc.centerY;
+  const bulkCenter = (grid - 1) / 2;
+  let sumAbs = 0;
+  let vx = 0;
+  let vy = 0;
+  for (let y = 1; y < grid - 1; y++) {
+    for (let x = 1; x < grid - 1; x++) {
+      const id = y * grid + x;
+      const diff = perturbed[id] - baseline[id];
+      if (!Number.isFinite(diff) || Math.abs(diff) <= 1e-9) continue;
+      const dx = centerX - x;
+      const dy = centerY - y;
+      vx += diff * dx;
+      vy += diff * dy;
+      sumAbs += Math.abs(diff);
+    }
+  }
+  if (sumAbs > 0) {
+    vx /= sumAbs;
+    vy /= sumAbs;
+  } else {
+    vx = 0;
+    vy = 0;
+  }
+  const magnitude = Math.hypot(vx, vy);
+  const targetX = centerX - bulkCenter;
+  const targetY = centerY - bulkCenter;
+  const targetMag = Math.hypot(targetX, targetY) || 1;
+  const alignment = magnitude > 0
+    ? (vx * targetX + vy * targetY) / (magnitude * targetMag)
+    : 0;
+  return {
+    flow: { x: vx, y: vy, magnitude, alignment },
+    totalDelta: sumAbs,
+  };
+}
+
+function normalizeField(field: ArrayLike<number>, grid: number): Float32Array {
+  const total = grid * grid;
+  const arr = new Float32Array(total);
+  for (let i = 0; i < total; i++) {
+    const value = field[i];
+    arr[i] = clampFinite(Number.isFinite(value as number) ? (value as number) : 0);
+  }
+  return arr;
+}
+
+export function measureEntropyForces(
+  field: ArrayLike<number>,
+  grid: number,
+  options: EntropyForceOptions = {},
+): EntropyForceResult[] {
+  if (!Number.isFinite(grid) || grid <= 1) {
+    return [];
+  }
+  const base = normalizeField(field, grid);
+  const boundaryMask = buildBoundaryMask(grid);
+  const iterations = Math.max(1, Math.floor(options.iterations ?? DEFAULT_ITERATIONS));
+  const rate = options.diffusionRate ?? DEFAULT_DIFFUSION;
+  const baseline = runDiffusion(base, grid, boundaryMask, iterations, rate);
+  const arcs = sampleBoundaryEntropy(base, grid, options.arcLength);
+  const delta = options.delta ?? DEFAULT_DELTA;
+  const results: EntropyForceResult[] = [];
+  for (const arc of arcs) {
+    const perturbedBoundary = applyArcPerturbation(base, arc, delta);
+    const propagated = runDiffusion(perturbedBoundary, grid, boundaryMask, iterations, rate);
+    const { flow, totalDelta } = computeFlowVector(baseline, propagated, grid, arc);
+    results.push({ arc, flow, totalDelta });
+  }
+  return results;
+}
+
+export function dominantEntropyForce(
+  field: ArrayLike<number>,
+  grid: number,
+  options?: EntropyForceOptions,
+): EntropyForceResult | null {
+  const results = measureEntropyForces(field, grid, options);
+  if (!results.length) return null;
+  results.sort((a, b) => b.arc.entropy - a.arc.entropy);
+  return results[0];
+}

--- a/src/reconstruction.ts
+++ b/src/reconstruction.ts
@@ -1,0 +1,485 @@
+export type BoundarySample = {
+  boundary: Float32Array;
+  bulk: Float32Array;
+  grid: number;
+};
+
+export type TrainOptions = {
+  type?: "linear" | "mlp";
+  includeBias?: boolean;
+  ridge?: number;
+  hiddenSize?: number;
+  epochs?: number;
+  learningRate?: number;
+  l2?: number;
+};
+
+export type MaskOptions = {
+  coverage?: number;
+  mode?: "contiguous" | "alternate";
+  offset?: number;
+};
+
+type LinearModel = {
+  type: "linear";
+  inputSize: number;
+  outputSize: number;
+  includeBias: boolean;
+  weights: Float64Array; // stored column-major: i * output + j
+};
+
+type MLPModel = {
+  type: "mlp";
+  inputSize: number;
+  hiddenSize: number;
+  outputSize: number;
+  includeBias: boolean;
+  w1: Float64Array; // hidden x input
+  b1: Float64Array; // hidden
+  w2: Float64Array; // output x hidden
+  b2: Float64Array; // output
+  activation: "relu";
+};
+
+export type ReconstructionModel = LinearModel | MLPModel;
+
+export type ReconstructionMetrics = {
+  mse: number;
+  mseInterior: number;
+  psnr: number;
+  psnrInterior: number;
+};
+
+export type EvaluationResult = {
+  metrics: ReconstructionMetrics;
+  predicted: Float32Array;
+  maskedBoundary: Float32Array;
+  mask: Uint8Array;
+};
+
+const EPS = 1e-9;
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function captureSample(field: ArrayLike<number>, grid: number): BoundarySample {
+  assert(grid > 1, "grid must be greater than 1");
+  const total = grid * grid;
+  assert(field.length === total, "field length does not match grid size");
+  const boundary = new Float32Array(grid * 4 - 4);
+  let ptr = 0;
+  // top row
+  for (let x = 0; x < grid; x++) {
+    boundary[ptr++] = Number(field[x]);
+  }
+  // right column (excluding corners)
+  for (let y = 1; y < grid - 1; y++) {
+    boundary[ptr++] = Number(field[y * grid + (grid - 1)]);
+  }
+  // bottom row (right to left)
+  for (let x = grid - 1; x >= 0; x--) {
+    boundary[ptr++] = Number(field[(grid - 1) * grid + x]);
+  }
+  // left column (excluding corners, bottom to top)
+  for (let y = grid - 2; y >= 1; y--) {
+    boundary[ptr++] = Number(field[y * grid]);
+  }
+  const bulk = new Float32Array(total);
+  for (let i = 0; i < total; i++) {
+    bulk[i] = Number(field[i]);
+  }
+  return { boundary, bulk, grid };
+}
+
+function prepareInputVector(boundary: ArrayLike<number>, includeBias: boolean): Float64Array {
+  const len = boundary.length;
+  const out = new Float64Array(len + (includeBias ? 1 : 0));
+  for (let i = 0; i < len; i++) {
+    out[i] = Number(boundary[i]);
+  }
+  if (includeBias) {
+    out[len] = 1;
+  }
+  return out;
+}
+
+function trainLinearModel(samples: BoundarySample[], options: Required<Pick<TrainOptions, "includeBias" | "ridge" | "l2">>): LinearModel {
+  const { includeBias, ridge, l2 } = options;
+  assert(samples.length > 0, "no samples provided");
+  const inputBase = samples[0].boundary.length;
+  const outputSize = samples[0].bulk.length;
+  const augmentedSize = inputBase + (includeBias ? 1 : 0);
+  const xtx = new Float64Array(augmentedSize * augmentedSize);
+  const xty = new Float64Array(augmentedSize * outputSize);
+
+  for (const sample of samples) {
+    assert(sample.boundary.length === inputBase, "inconsistent boundary length");
+    assert(sample.bulk.length === outputSize, "inconsistent bulk length");
+    const x = prepareInputVector(sample.boundary, includeBias);
+    const y = sample.bulk;
+    for (let i = 0; i < augmentedSize; i++) {
+      const xi = x[i];
+      for (let j = 0; j < augmentedSize; j++) {
+        xtx[i * augmentedSize + j] += xi * x[j];
+      }
+      for (let k = 0; k < outputSize; k++) {
+        xty[i * outputSize + k] += xi * y[k];
+      }
+    }
+  }
+
+  const matrix = xtx.slice();
+  const diagRegularizer = ridge + l2;
+  for (let i = 0; i < augmentedSize; i++) {
+    matrix[i * augmentedSize + i] += diagRegularizer;
+  }
+
+  const L = cholesky(matrix, augmentedSize);
+  const weights = new Float64Array(augmentedSize * outputSize);
+  const column = new Float64Array(augmentedSize);
+  for (let k = 0; k < outputSize; k++) {
+    for (let i = 0; i < augmentedSize; i++) {
+      column[i] = xty[i * outputSize + k];
+    }
+    const solved = choleskySolve(L, column, augmentedSize);
+    for (let i = 0; i < augmentedSize; i++) {
+      weights[i * outputSize + k] = solved[i];
+    }
+  }
+
+  return {
+    type: "linear",
+    inputSize: inputBase,
+    outputSize,
+    includeBias,
+    weights,
+  };
+}
+
+function randomUniform(scale: number): number {
+  return (Math.random() * 2 - 1) * scale;
+}
+
+function trainMlpModel(samples: BoundarySample[], options: Required<Pick<TrainOptions, "hiddenSize" | "epochs" | "learningRate">>): MLPModel {
+  const { hiddenSize, epochs, learningRate } = options;
+  assert(samples.length > 0, "no samples provided");
+  const inputSize = samples[0].boundary.length;
+  const outputSize = samples[0].bulk.length;
+  const w1 = new Float64Array(hiddenSize * inputSize);
+  const b1 = new Float64Array(hiddenSize);
+  const w2 = new Float64Array(outputSize * hiddenSize);
+  const b2 = new Float64Array(outputSize);
+
+  const initScale1 = Math.sqrt(2 / Math.max(1, inputSize));
+  const initScale2 = Math.sqrt(2 / Math.max(1, hiddenSize));
+
+  for (let i = 0; i < w1.length; i++) {
+    w1[i] = randomUniform(initScale1);
+  }
+  for (let i = 0; i < hiddenSize; i++) {
+    b1[i] = 0;
+  }
+  for (let i = 0; i < w2.length; i++) {
+    w2[i] = randomUniform(initScale2);
+  }
+  for (let i = 0; i < outputSize; i++) {
+    b2[i] = 0;
+  }
+
+  const gradW1 = new Float64Array(hiddenSize * inputSize);
+  const gradB1 = new Float64Array(hiddenSize);
+  const gradW2 = new Float64Array(outputSize * hiddenSize);
+  const gradB2 = new Float64Array(outputSize);
+  const z1 = new Float64Array(hiddenSize);
+  const a1 = new Float64Array(hiddenSize);
+  const deltaHidden = new Float64Array(hiddenSize);
+  const deltaOutput = new Float64Array(outputSize);
+
+  const inputs = samples.map(sample => {
+    assert(sample.boundary.length === inputSize, "inconsistent boundary length");
+    assert(sample.bulk.length === outputSize, "inconsistent bulk length");
+    const arr = new Float64Array(inputSize);
+    for (let i = 0; i < inputSize; i++) {
+      arr[i] = sample.boundary[i];
+    }
+    return arr;
+  });
+
+  const targets = samples.map(sample => {
+    const arr = new Float64Array(outputSize);
+    for (let i = 0; i < outputSize; i++) {
+      arr[i] = sample.bulk[i];
+    }
+    return arr;
+  });
+
+  const datasetSize = samples.length;
+  const invSize = 1 / datasetSize;
+
+  for (let epoch = 0; epoch < epochs; epoch++) {
+    gradW1.fill(0);
+    gradB1.fill(0);
+    gradW2.fill(0);
+    gradB2.fill(0);
+
+    for (let n = 0; n < datasetSize; n++) {
+      const x = inputs[n];
+      const y = targets[n];
+
+      // forward pass
+      for (let h = 0; h < hiddenSize; h++) {
+        let sum = b1[h];
+        for (let i = 0; i < inputSize; i++) {
+          sum += w1[h * inputSize + i] * x[i];
+        }
+        z1[h] = sum;
+        a1[h] = sum > 0 ? sum : 0; // ReLU
+      }
+
+      for (let j = 0; j < outputSize; j++) {
+        let sum = b2[j];
+        for (let h = 0; h < hiddenSize; h++) {
+          sum += w2[j * hiddenSize + h] * a1[h];
+        }
+        deltaOutput[j] = sum - y[j];
+      }
+
+      // backward pass
+      for (let j = 0; j < outputSize; j++) {
+        const grad = deltaOutput[j];
+        gradB2[j] += grad;
+        for (let h = 0; h < hiddenSize; h++) {
+          gradW2[j * hiddenSize + h] += grad * a1[h];
+        }
+      }
+
+      for (let h = 0; h < hiddenSize; h++) {
+        let grad = 0;
+        for (let j = 0; j < outputSize; j++) {
+          grad += w2[j * hiddenSize + h] * deltaOutput[j];
+        }
+        grad = z1[h] > 0 ? grad : 0;
+        deltaHidden[h] = grad;
+        gradB1[h] += grad;
+        for (let i = 0; i < inputSize; i++) {
+          gradW1[h * inputSize + i] += grad * x[i];
+        }
+      }
+    }
+
+    const step = learningRate * invSize;
+    for (let i = 0; i < gradW1.length; i++) {
+      w1[i] -= step * gradW1[i];
+    }
+    for (let i = 0; i < gradB1.length; i++) {
+      b1[i] -= step * gradB1[i];
+    }
+    for (let i = 0; i < gradW2.length; i++) {
+      w2[i] -= step * gradW2[i];
+    }
+    for (let i = 0; i < gradB2.length; i++) {
+      b2[i] -= step * gradB2[i];
+    }
+  }
+
+  return {
+    type: "mlp",
+    inputSize,
+    hiddenSize,
+    outputSize,
+    includeBias: false,
+    w1,
+    b1,
+    w2,
+    b2,
+    activation: "relu",
+  };
+}
+
+export function trainDecoder(samples: BoundarySample[], options: TrainOptions = {}): ReconstructionModel {
+  if (!samples.length) {
+    throw new Error("No hay muestras suficientes para entrenar el decodificador");
+  }
+  const type = options.type ?? "linear";
+  if (type === "linear") {
+    const includeBias = options.includeBias ?? true;
+    const ridge = options.ridge ?? 1e-3;
+    const l2 = options.l2 ?? 1e-5;
+    return trainLinearModel(samples, { includeBias, ridge, l2 });
+  }
+  const hiddenSize = options.hiddenSize ?? Math.max(8, Math.ceil(samples[0].boundary.length / 2));
+  const epochs = options.epochs ?? 200;
+  const learningRate = options.learningRate ?? 0.01;
+  return trainMlpModel(samples, { hiddenSize, epochs, learningRate });
+}
+
+export function runDecoder(model: ReconstructionModel, boundary: ArrayLike<number>): Float32Array {
+  if (model.type === "linear") {
+    assert(boundary.length === model.inputSize, "boundary length mismatch for linear model");
+    const inputVec = prepareInputVector(boundary, model.includeBias);
+    const { outputSize, weights } = model;
+    const output = new Float32Array(outputSize);
+    for (let j = 0; j < outputSize; j++) {
+      let sum = 0;
+      for (let i = 0; i < inputVec.length; i++) {
+        sum += inputVec[i] * weights[i * outputSize + j];
+      }
+      output[j] = clamp01(sum);
+    }
+    return output;
+  }
+
+  assert(boundary.length === model.inputSize, "boundary length mismatch for MLP model");
+  const input = new Float64Array(model.inputSize);
+  for (let i = 0; i < model.inputSize; i++) {
+    input[i] = boundary[i];
+  }
+  const hidden = new Float64Array(model.hiddenSize);
+  for (let h = 0; h < model.hiddenSize; h++) {
+    let sum = model.b1[h];
+    for (let i = 0; i < model.inputSize; i++) {
+      sum += model.w1[h * model.inputSize + i] * input[i];
+    }
+    hidden[h] = sum > 0 ? sum : 0;
+  }
+  const output = new Float32Array(model.outputSize);
+  for (let j = 0; j < model.outputSize; j++) {
+    let sum = model.b2[j];
+    for (let h = 0; h < model.hiddenSize; h++) {
+      sum += model.w2[j * model.hiddenSize + h] * hidden[h];
+    }
+    output[j] = clamp01(sum);
+  }
+  return output;
+}
+
+export function maskBoundary(boundary: ArrayLike<number>, options: MaskOptions = {}): { masked: Float32Array; mask: Uint8Array } {
+  const len = boundary.length;
+  const masked = new Float32Array(len);
+  const mask = new Uint8Array(len);
+  if (len === 0) {
+    return { masked, mask };
+  }
+  const coverage = Math.max(0, Math.min(1, options.coverage ?? 1));
+  if (coverage >= 0.999) {
+    for (let i = 0; i < len; i++) {
+      const value = Number(boundary[i]);
+      masked[i] = value;
+      mask[i] = 1;
+    }
+    return { masked, mask };
+  }
+
+  const mode = options.mode ?? "contiguous";
+  const keepCount = Math.max(1, Math.floor(len * coverage));
+  if (mode === "alternate") {
+    const step = len / keepCount;
+    for (let i = 0; i < keepCount; i++) {
+      const idx = Math.min(len - 1, Math.round(i * step));
+      masked[idx] = Number(boundary[idx]);
+      mask[idx] = 1;
+    }
+    return { masked, mask };
+  }
+
+  // contiguous chunk with configurable offset (0..1)
+  const offset = Math.max(0, Math.min(1, options.offset ?? 0));
+  const start = Math.floor((len - keepCount) * offset);
+  const end = start + keepCount;
+  for (let i = start; i < end && i < len; i++) {
+    masked[i] = Number(boundary[i]);
+    mask[i] = 1;
+  }
+  return { masked, mask };
+}
+
+export function computePSNR(mse: number, peak = 1): number {
+  if (mse <= EPS) {
+    return Infinity;
+  }
+  return 20 * Math.log10(peak) - 10 * Math.log10(mse);
+}
+
+export function computeReconstructionMetrics(sample: BoundarySample, predicted: ArrayLike<number>): ReconstructionMetrics {
+  assert(predicted.length === sample.bulk.length, "predicted vector length mismatch");
+  const { bulk, grid } = sample;
+  const total = bulk.length;
+  let mse = 0;
+  let mseInterior = 0;
+  let interiorCount = 0;
+  for (let y = 0; y < grid; y++) {
+    for (let x = 0; x < grid; x++) {
+      const idx = y * grid + x;
+      const diff = bulk[idx] - Number(predicted[idx]);
+      mse += diff * diff;
+      const interior = x > 0 && x < grid - 1 && y > 0 && y < grid - 1;
+      if (interior) {
+        mseInterior += diff * diff;
+        interiorCount += 1;
+      }
+    }
+  }
+  mse /= total || 1;
+  mseInterior = interiorCount > 0 ? mseInterior / interiorCount : mse;
+  const psnr = computePSNR(mse);
+  const psnrInterior = computePSNR(mseInterior);
+  return { mse, mseInterior, psnr, psnrInterior };
+}
+
+export function evaluateReconstruction(sample: BoundarySample, model: ReconstructionModel, options: MaskOptions = {}): EvaluationResult {
+  const { masked, mask } = maskBoundary(sample.boundary, options);
+  const predicted = runDecoder(model, masked);
+  const metrics = computeReconstructionMetrics(sample, predicted);
+  return { metrics, predicted, maskedBoundary: masked, mask };
+}
+
+function cholesky(matrix: Float64Array, size: number): Float64Array {
+  const L = new Float64Array(size * size);
+  for (let i = 0; i < size; i++) {
+    for (let j = 0; j <= i; j++) {
+      let sum = matrix[i * size + j];
+      for (let k = 0; k < j; k++) {
+        sum -= L[i * size + k] * L[j * size + k];
+      }
+      if (i === j) {
+        if (sum < EPS) {
+          sum = EPS;
+        }
+        L[i * size + j] = Math.sqrt(sum);
+      } else {
+        L[i * size + j] = sum / L[j * size + j];
+      }
+    }
+  }
+  return L;
+}
+
+function choleskySolve(L: Float64Array, b: Float64Array, size: number): Float64Array {
+  const y = new Float64Array(size);
+  for (let i = 0; i < size; i++) {
+    let sum = b[i];
+    for (let k = 0; k < i; k++) {
+      sum -= L[i * size + k] * y[k];
+    }
+    y[i] = sum / L[i * size + i];
+  }
+  const x = new Float64Array(size);
+  for (let i = size - 1; i >= 0; i--) {
+    let sum = y[i];
+    for (let k = i + 1; k < size; k++) {
+      sum -= L[k * size + i] * x[k];
+    }
+    x[i] = sum / L[i * size + i];
+  }
+  return x;
+}
+

--- a/src/ui/ExperimentsPanel.tsx
+++ b/src/ui/ExperimentsPanel.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+
+type ExperimentsPanelProps = {
+  onOpenDoc: () => void;
+};
+
+const MAP_ROWS: Array<{ phi: string; lambda: string }> = [
+  { phi: "Fluctuaciones cuánticas del vacío", lambda: "Principio de incertidumbre (Heisenberg)" },
+  { phi: "Creación/aniquilación de pares partícula–antipartícula", lambda: "Conservación de energía y carga" },
+  { phi: "Oscilación de neutrinos", lambda: "Matriz PMNS (mezcla de sabores), masa mínima de neutrinos" },
+  { phi: "Reacciones nucleares (fusión, fisión)", lambda: "Fuerza nuclear fuerte y débil, barrera de Coulomb" },
+  { phi: "Tunelamiento cuántico", lambda: "Probabilidad cuántica, función de onda, no-clonación" },
+  { phi: "Formación de moléculas y enlaces químicos", lambda: "Constante de estructura fina (α), mecánica cuántica molecular" },
+  { phi: "Transiciones de fase (sólido–líquido–gas–plasma–BEC)", lambda: "Termodinámica (leyes de conservación, entropía)" },
+  { phi: "Actividad volcánica, tectónica y sísmica", lambda: "Física de materiales, gravedad, geodinámica" },
+  { phi: "Fenómenos atmosféricos (huracanes, auroras, arcoíris)", lambda: "Termodinámica, electromagnetismo, dinámica de fluidos" },
+  { phi: "Mutación y evolución biológica", lambda: "ADN, tasas de mutación, leyes de la selección natural" },
+  { phi: "Emergencia de conciencia", lambda: "Neurobiología, coherencia cuántica (hipótesis en debate)" },
+  { phi: "Muerte y regeneración parcial", lambda: "Límite de reparación celular, entropía biológica" },
+  { phi: "Formación de estrellas y planetas", lambda: "Colapso gravitatorio, límite de Jeans" },
+  { phi: "Supernovas, hipernovas, kilonovas", lambda: "Límite de Chandrasekhar, TOV" },
+  { phi: "Formación de agujeros negros", lambda: "Relatividad general, horizonte de eventos" },
+  { phi: "Evaporación de agujeros negros (Hawking)", lambda: "Mecánica cuántica + relatividad (aún no unificada)" },
+  { phi: "Colisiones galácticas", lambda: "Gravedad newtoniana/relativista, conservación de momento" },
+  { phi: "Ondas gravitacionales", lambda: "Relatividad general, energía gravitacional" },
+  { phi: "Expansión cósmica acelerada", lambda: "Constante cosmológica Λ, energía oscura" },
+  { phi: "Posible Big Bang e inflaciones", lambda: "Condiciones iniciales del universo, simetrías rotas" },
+  { phi: "Posibles universos burbuja", lambda: "Modelos inflacionarios multiverso" },
+  { phi: "Lenguaje, cultura, sociedades", lambda: "Neurociencia, evolución cognitiva, dinámica social" },
+  { phi: "Ciencia, arte, tecnología", lambda: "Límites de energía y recursos disponibles" },
+  { phi: "Computación e inteligencia artificial", lambda: "Teoría de la información, complejidad computacional" },
+  { phi: "Guerra y cooperación", lambda: "Psicología, sociología, recursos materiales" },
+  { phi: "Colonización espacial", lambda: "Ley de Tsiolkovsky, restricciones energéticas" },
+  { phi: "Ingeniería genética y biotecnología", lambda: "Biología molecular, bioética, límites mutacionales" },
+  { phi: "Ciborgs y transhumanismo", lambda: "Ingeniería biomédica, integración hombre-máquina" },
+  { phi: "Posible contacto extraterrestre", lambda: "Límites de detección (SETI, paradoja de Fermi)" },
+  { phi: "Colonización interestelar", lambda: "Relatividad especial (velocidad < c), energía finita" },
+];
+
+export function ExperimentsPanel({ onOpenDoc }: ExperimentsPanelProps) {
+  return (
+    <section className="bg-slate-900/80 border border-slate-800 rounded-2xl p-4 space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Mapa Φ ∘ 𝓛(x)</h2>
+        <p className="text-sm text-slate-400">Sucesos potenciales frente a estructuras limitantes.</p>
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm border-separate border-spacing-y-1 min-w-[480px]">
+          <thead>
+            <tr className="text-slate-400">
+              <th className="px-3 py-2 w-1/2">Φ — Sucesos y hechos posibles</th>
+              <th className="px-3 py-2 w-1/2">𝓛 — Estructuras limitantes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {MAP_ROWS.map((row) => (
+              <tr key={`${row.phi}-${row.lambda}`} className="bg-slate-900/60 align-top">
+                <td className="px-3 py-2 text-slate-200">{row.phi}</td>
+                <td className="px-3 py-2 text-slate-200">{row.lambda}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <section className="space-y-2 text-sm text-slate-200">
+        <h3 className="text-sm font-semibold text-slate-300">Interpretación (Φ, 𝓛, R)</h3>
+        <p>
+          <strong className="text-slate-100">Φ</strong> representa el abanico de sucesos posibles, desde procesos cuánticos hasta
+          fenómenos sociales y tecnológicos.
+        </p>
+        <p>
+          <strong className="text-slate-100">𝓛</strong> describe las leyes, constantes y límites que estructuran o restringen esos
+          sucesos, determinando qué potencialidades pueden manifestarse.
+        </p>
+        <p>
+          La realidad <strong className="text-slate-100">R</strong> emerge donde ambas columnas coinciden: cuando un suceso posible
+          cumple las condiciones limitantes, se actualiza como evento concreto sin alterar el motor holográfico.
+        </p>
+      </section>
+
+      <div className="flex justify-end">
+        <button
+          className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm"
+          onClick={onOpenDoc}
+          type="button"
+        >
+          Abrir en GitHub
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -8,7 +8,9 @@ type HeaderProps = {
   onExportCsv: () => void;
   onExportCapture: () => void;
   onToggleExperiments: () => void;
+  onToggleMetrics: () => void;
   experimentsOpen: boolean;
+  metricsOpen: boolean;
 };
 
 export function Header({
@@ -19,11 +21,14 @@ export function Header({
   onExportCsv,
   onExportCapture,
   onToggleExperiments,
+  onToggleMetrics,
   experimentsOpen,
+  metricsOpen,
 }: HeaderProps) {
-  const experimentsButtonClassName = experimentsOpen
-    ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
-    : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
+  const toggleButtonClassName = (isActive: boolean) =>
+    isActive
+      ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
+      : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
 
   return (
     <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
@@ -48,7 +53,15 @@ export function Header({
           Exportar captura
         </button>
         <button
-          className={experimentsButtonClassName}
+          className={toggleButtonClassName(metricsOpen)}
+          onClick={onToggleMetrics}
+          aria-pressed={metricsOpen}
+          type="button"
+        >
+          {metricsOpen ? "Cerrar métricas" : "Métricas básicas"}
+        </button>
+        <button
+          className={toggleButtonClassName(experimentsOpen)}
           onClick={onToggleExperiments}
           aria-pressed={experimentsOpen}
           type="button"

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+type HeaderProps = {
+  onStartAll: () => void;
+  onPauseAll: () => void;
+  onResetSoft: () => void;
+  onResetHard: () => void;
+  onExportCsv: () => void;
+  onExportCapture: () => void;
+  onToggleExperiments: () => void;
+  experimentsOpen: boolean;
+};
+
+export function Header({
+  onStartAll,
+  onPauseAll,
+  onResetSoft,
+  onResetHard,
+  onExportCsv,
+  onExportCapture,
+  onToggleExperiments,
+  experimentsOpen,
+}: HeaderProps) {
+  const experimentsButtonClassName = experimentsOpen
+    ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
+    : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
+
+  return (
+    <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
+      <h1 className="text-xl sm:text-2xl font-bold text-center sm:text-left">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
+      <div className="flex flex-wrap justify-center sm:justify-end gap-2">
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onStartAll}>
+          Iniciar todo
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onPauseAll}>
+          Pausar todo
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onResetSoft}>
+          Reset 𝓣/R
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={onResetHard}>
+          Big Bang ♻︎
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onExportCsv}>
+          Exportar CSV
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onExportCapture}>
+          Exportar captura
+        </button>
+        <button
+          className={experimentsButtonClassName}
+          onClick={onToggleExperiments}
+          aria-pressed={experimentsOpen}
+          type="button"
+        >
+          {experimentsOpen ? "Cerrar mapa Φ ∘ 𝓛(x)" : "Mapa Φ ∘ 𝓛(x)"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/ui/MetricsPanel.tsx
+++ b/src/ui/MetricsPanel.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { getBoundaryMode, getR2Area, getR2Perimeter } from "../metrics";
+
+type MetricsPanelProps = {
+  seed?: number | string | null;
+  depth?: number | string | null;
+};
+
+function formatR2(value: number | null): string {
+  if (value == null) {
+    return "N/D";
+  }
+  return value.toFixed(3);
+}
+
+function formatBoundary(value: boolean | null): string {
+  if (value == null) {
+    return "N/D";
+  }
+  return value ? "ON" : "OFF";
+}
+
+function formatScalar(value: number | string | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "N/D";
+  }
+  return typeof value === "number" ? value.toString() : value;
+}
+
+export function MetricsPanel({ seed, depth }: MetricsPanelProps) {
+  const r2Perimeter = getR2Perimeter();
+  const r2Area = getR2Area();
+  const boundaryMode = getBoundaryMode();
+
+  const handleExport = () => {
+    const timestamp = new Date().toISOString();
+    const rows = [
+      "seed,depth,R2_perimeter,R2_area,timestamp",
+      [
+        formatScalar(seed),
+        formatScalar(depth),
+        r2Perimeter != null ? r2Perimeter.toString() : "N/D",
+        r2Area != null ? r2Area.toString() : "N/D",
+        timestamp,
+      ].join(","),
+    ];
+
+    const blob = new Blob([rows.join("\n")], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `metricas-experimentos-${timestamp.replace(/[:.]/g, "-")}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section className="bg-slate-900/80 border border-slate-800 rounded-2xl p-4 space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Métricas básicas</h2>
+        <p className="text-sm text-slate-400">Lectura de indicadores actuales del sistema.</p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">R² (perímetro)</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatR2(r2Perimeter)}</div>
+        </div>
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">R² (área)</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatR2(r2Area)}</div>
+        </div>
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">Boundary Mode</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatBoundary(boundaryMode)}</div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 text-sm text-slate-300">
+        <div className="bg-slate-900/40 rounded-xl p-3 border border-slate-800/40">
+          <div className="text-xs uppercase tracking-wide text-slate-500">Seed base</div>
+          <div className="text-base text-slate-100">{formatScalar(seed)}</div>
+        </div>
+        <div className="bg-slate-900/40 rounded-xl p-3 border border-slate-800/40">
+          <div className="text-xs uppercase tracking-wide text-slate-500">Profundidad (depth)</div>
+          <div className="text-base text-slate-100">{formatScalar(depth)}</div>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm"
+          onClick={handleExport}
+          type="button"
+        >
+          Exportar CSV (experimentos)
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/controls.tsx
+++ b/src/ui/controls.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+
+type HolographicControlsProps = {
+  holographicMode: boolean;
+  setHolographicMode: (value: boolean) => void;
+  boundaryDepth: number;
+  setBoundaryDepth: (value: number) => void;
+  boundaryNoise: number;
+  setBoundaryNoise: (value: number) => void;
+  boundaryKernelMix: number;
+  setBoundaryKernelMix: (value: number) => void;
+};
+
+export function HolographicControls({
+  holographicMode,
+  setHolographicMode,
+  boundaryDepth,
+  setBoundaryDepth,
+  boundaryNoise,
+  setBoundaryNoise,
+  boundaryKernelMix,
+  setBoundaryKernelMix,
+}: HolographicControlsProps) {
+  const handleDepth = (value: string) => {
+    const parsed = parseInt(value, 10);
+    if (!Number.isNaN(parsed)) {
+      setBoundaryDepth(Math.max(0, Math.min(128, parsed)));
+    }
+  };
+
+  const handleNoise = (value: string) => {
+    const parsed = parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      setBoundaryNoise(Math.max(0, Math.min(1, parsed)));
+    }
+  };
+
+  const handleKernelMix = (value: string) => {
+    const parsed = parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      setBoundaryKernelMix(Math.max(0, Math.min(1, parsed)));
+    }
+  };
+
+  return (
+    <div style={{ border: "1px solid #444", borderRadius: 8, padding: 12, display: "grid", gap: 10 }}>
+      <strong>Modo holográfico (𝓛 en la frontera)</strong>
+      <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <input
+          type="checkbox"
+          checked={holographicMode}
+          onChange={(event) => setHolographicMode(event.target.checked)}
+        />
+        <span>Activar propagación boundary-first</span>
+      </label>
+      <small style={{ color: "#aaa" }}>
+        Con el modo holográfico activo, la estructura limitante 𝓛 se siembra en la frontera y se difunde por capas hacia el bulk. El
+        resultado R depende de la configuración de estas capas externas, respetando el criterio holográfico.
+      </small>
+      <div style={{ display: "grid", gridTemplateColumns: "140px 1fr 60px", gap: 8, alignItems: "center" }}>
+        <span>Profundidad de capas</span>
+        <input
+          type="range"
+          min={0}
+          max={128}
+          step={1}
+          value={Math.max(0, Math.min(128, Math.round(boundaryDepth)))}
+          onChange={(event) => handleDepth(event.target.value)}
+          disabled={!holographicMode}
+        />
+        <code>{boundaryDepth}</code>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "140px 1fr 60px", gap: 8, alignItems: "center" }}>
+        <span>Ruido de frontera</span>
+        <input
+          type="range"
+          min={0}
+          max={0.5}
+          step={0.01}
+          value={Math.max(0, Math.min(0.5, boundaryNoise))}
+          onChange={(event) => handleNoise(event.target.value)}
+          disabled={!holographicMode}
+        />
+        <code>{boundaryNoise.toFixed(2)}</code>
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "140px 1fr 60px", gap: 8, alignItems: "center" }}>
+        <span>Kernel mix</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={Math.max(0, Math.min(1, boundaryKernelMix))}
+          onChange={(event) => handleKernelMix(event.target.value)}
+          disabled={!holographicMode}
+        />
+        <code>{boundaryKernelMix.toFixed(2)}</code>
+      </div>
+      <small style={{ color: "#888" }}>
+        Profundidades mayores extienden la influencia holográfica hacia el bulk. El ruido introduce variaciones deterministas en la
+        frontera (Axioma IX), mientras que el mix ajusta el kernel usado en la propagación (entre SMOOTH y RIGID).
+      </small>
+    </div>
+  );
+}

--- a/src/ui/metricsPanel.tsx
+++ b/src/ui/metricsPanel.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import type { AreaLawMetrics } from "../metrics";
+
+type MetricsPanelProps = {
+  metrics?: AreaLawMetrics | null;
+  holographicMode?: boolean;
+  title?: string;
+};
+
+function formatNumber(value: number | undefined): string {
+  if (value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  return value.toFixed(3);
+}
+
+export function MetricsPanel({ metrics, holographicMode, title }: MetricsPanelProps) {
+  const perimeterR2 = metrics?.perimeterFit.r2 ?? 0;
+  const areaR2 = metrics?.areaFit.r2 ?? 0;
+  const samples = metrics?.regions.length ?? 0;
+  const highlightPerimeter = holographicMode && perimeterR2 >= areaR2;
+
+  return (
+    <div style={{ border: "1px solid #444", borderRadius: 8, padding: 12, display: "grid", gap: 8 }}>
+      <strong>{title ?? "Ley de área holográfica"}</strong>
+      <small style={{ color: "#a0aec0" }}>
+        Se evalúa la entropía S(A) de subregiones rectangulares del bulk y se ajustan dos regresiones lineales: una con el
+        perímetro y otra con el área. Si la holografía domina, la correlación con el perímetro supera claramente a la del área.
+      </small>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 8 }}>
+        <MetricCard
+          label="R² — Perímetro"
+          value={formatNumber(perimeterR2)}
+          accent={highlightPerimeter ? "#34d399" : undefined}
+        />
+        <MetricCard label="R² — Área" value={formatNumber(areaR2)} accent={!highlightPerimeter ? "#fbbf24" : "#94a3b8"} />
+      </div>
+      <div style={{ fontSize: 12, color: "#a0aec0" }}>
+        Muestras: {samples} &nbsp;|
+        &nbsp; α = {formatNumber(metrics?.perimeterFit.slope)} &nbsp; β = {formatNumber(metrics?.areaFit.slope)}
+      </div>
+      {holographicMode ? (
+        <em style={{ color: highlightPerimeter ? "#34d399" : "#fbbf24", fontSize: 12 }}>
+          {highlightPerimeter
+            ? "Escalado holográfico detectado: S(A) sigue el perímetro."
+            : "Advertencia: la correlación con el área supera a la del perímetro."}
+        </em>
+      ) : (
+        <small style={{ color: "#94a3b8" }}>Activa el modo holográfico para contrastar la ley de área.</small>
+      )}
+    </div>
+  );
+}
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  accent?: string;
+};
+
+function MetricCard({ label, value, accent }: MetricCardProps) {
+  const color = accent ?? "#f8fafc";
+  return (
+    <div style={{ border: "1px solid #333", borderRadius: 6, padding: 10 }}>
+      <div style={{ fontSize: 12, color: "#cbd5f5" }}>{label}</div>
+      <div style={{ fontWeight: 700, color, fontSize: 18 }}>{value}</div>
+    </div>
+  );
+}
+
+export default MetricsPanel;
+

--- a/src/ui/reconPanel.tsx
+++ b/src/ui/reconPanel.tsx
@@ -1,0 +1,276 @@
+import React from "react";
+import type { ReconstructionMetrics } from "../reconstruction";
+
+type ModeOption = "contiguous" | "alternate";
+
+type TrainingHandlers = {
+  onFreeze?: () => void;
+  onClear?: () => void;
+  onTrainLinear?: () => void;
+  onTrainMLP?: () => void;
+};
+
+type ReconPanelProps = TrainingHandlers & {
+  datasetSize: number;
+  gridSize?: number;
+  boundaryLength?: number;
+  status?: string;
+  metrics?: ReconstructionMetrics | null;
+  coverage: number;
+  onCoverageChange?: (value: number) => void;
+  mode?: ModeOption;
+  onModeChange?: (mode: ModeOption) => void;
+  busy?: boolean;
+  modelType?: "linear" | "mlp" | null;
+  modelReady?: boolean;
+  holographicActive?: boolean;
+  degradePreview?: Array<{ coverage: number; psnr: number; psnrInterior?: number }>;
+};
+
+function formatNumber(value: number | undefined, digits = 4): string {
+  if (value === undefined || Number.isNaN(value)) {
+    return "—";
+  }
+  if (!Number.isFinite(value)) {
+    return "∞";
+  }
+  return value.toFixed(digits);
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export function ReconstructionPanel({
+  datasetSize,
+  gridSize,
+  boundaryLength,
+  status,
+  metrics,
+  coverage,
+  onCoverageChange,
+  mode = "contiguous",
+  onModeChange,
+  busy,
+  modelType,
+  modelReady,
+  holographicActive,
+  degradePreview,
+  onFreeze,
+  onClear,
+  onTrainLinear,
+  onTrainMLP,
+}: ReconPanelProps) {
+  const handleCoverage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const parsed = parseFloat(event.target.value);
+    if (Number.isNaN(parsed)) return;
+    onCoverageChange?.(Math.max(0, Math.min(1, parsed)));
+  };
+
+  const handleMode = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    onModeChange?.(event.target.value as ModeOption);
+  };
+
+  const disableActions = busy || !holographicActive;
+
+  return (
+    <div style={{ border: "1px solid #444", borderRadius: 8, padding: 12, display: "grid", gap: 12 }}>
+      <strong>Reconstrucción bulk-from-boundary</strong>
+      <small style={{ color: "#a0aec0" }}>
+        Congela configuraciones holográficas para entrenar un decodificador B que infiera el bulk completo desde la frontera.
+        Compara el error cuadrático medio (MSE) y el PSNR tanto en todo el lattice como solo en la región interna, y recorta la
+        cobertura de la frontera para simular un entanglement wedge parcial.
+      </small>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 8 }}>
+        <Stat label="Muestras" value={datasetSize.toString()} />
+        <Stat label="Grid" value={gridSize ? `${gridSize}×${gridSize}` : "—"} />
+        <Stat label="|∂A|" value={boundaryLength !== undefined ? boundaryLength.toString() : "—"} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button
+          onClick={onFreeze}
+          disabled={disableActions}
+          style={buttonStyle(disableActions)}
+        >
+          Congelar bulk
+        </button>
+        <button
+          onClick={onTrainLinear}
+          disabled={disableActions || datasetSize === 0}
+          style={buttonStyle(disableActions || datasetSize === 0)}
+        >
+          Entrenar lineal
+        </button>
+        <button
+          onClick={onTrainMLP}
+          disabled={disableActions || datasetSize === 0}
+          style={buttonStyle(disableActions || datasetSize === 0)}
+        >
+          Entrenar MLP
+        </button>
+        <button
+          onClick={onClear}
+          disabled={busy}
+          style={buttonStyle(!!busy)}
+        >
+          Resetear dataset
+        </button>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "140px 1fr 60px", gap: 8, alignItems: "center" }}>
+        <span>Cobertura de frontera</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={Math.max(0, Math.min(1, coverage))}
+          onChange={handleCoverage}
+        />
+        <code>{formatPercent(Math.max(0, Math.min(1, coverage)))}</code>
+      </div>
+
+      <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span>Modo de máscara</span>
+        <select value={mode} onChange={handleMode}>
+          <option value="contiguous">Contiguo</option>
+          <option value="alternate">Alterno</option>
+        </select>
+      </label>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(2,1fr)", gap: 8 }}>
+        <MetricCard label="MSE (global)" value={formatNumber(metrics?.mse)} color="#f87171" />
+        <MetricCard label="MSE (interior)" value={formatNumber(metrics?.mseInterior)} color="#fb923c" />
+        <MetricCard label="PSNR (global)" value={formatNumber(metrics?.psnr, 2)} color="#34d399" />
+        <MetricCard label="PSNR (interior)" value={formatNumber(metrics?.psnrInterior, 2)} color="#38bdf8" />
+      </div>
+
+      {modelType && (
+        <small style={{ color: "#cbd5f5" }}>
+          Modelo entrenado: {modelType.toUpperCase()} {modelReady ? "(listo)" : "(pendiente)"}
+        </small>
+      )}
+
+      {degradePreview && degradePreview.length > 0 && (
+        <div style={{ border: "1px solid #2d3748", borderRadius: 6, padding: 8 }}>
+          <div style={{ fontSize: 12, color: "#94a3b8", marginBottom: 4 }}>PSNR frente a recorte de frontera:</div>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+            <thead>
+              <tr style={{ color: "#cbd5f5" }}>
+                <th style={{ textAlign: "left" }}>Cobertura</th>
+                <th style={{ textAlign: "left" }}>PSNR</th>
+                <th style={{ textAlign: "left" }}>PSNR interior</th>
+              </tr>
+            </thead>
+            <tbody>
+              {degradePreview.map((entry) => (
+                <tr key={`coverage-${entry.coverage}`}>
+                  <td>{formatPercent(entry.coverage)}</td>
+                  <td>{formatNumber(entry.psnr, 2)}</td>
+                  <td>{formatNumber(entry.psnrInterior ?? entry.psnr, 2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <StatusMessage
+        status={status}
+        holographicActive={holographicActive}
+        datasetSize={datasetSize}
+        busy={busy}
+      />
+    </div>
+  );
+}
+
+const baseButton: React.CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: 6,
+  background: "#1e293b",
+  color: "#f8fafc",
+  border: "1px solid #334155",
+  cursor: "pointer",
+  fontSize: 12,
+};
+
+function buttonStyle(disabled: boolean): React.CSSProperties {
+  if (disabled) {
+    return {
+      ...baseButton,
+      background: "#1f2933",
+      color: "#64748b",
+      cursor: "not-allowed",
+    };
+  }
+  return {
+    ...baseButton,
+    background: "#1d4ed8",
+    border: "1px solid #1e40af",
+  };
+}
+
+type StatProps = {
+  label: string;
+  value: string;
+};
+
+function Stat({ label, value }: StatProps) {
+  return (
+    <div style={{ border: "1px solid #333", borderRadius: 6, padding: 10 }}>
+      <div style={{ fontSize: 12, color: "#94a3b8" }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 700, color: "#f8fafc" }}>{value}</div>
+    </div>
+  );
+}
+
+type MetricCardProps = {
+  label: string;
+  value: string;
+  color: string;
+};
+
+function MetricCard({ label, value, color }: MetricCardProps) {
+  return (
+    <div style={{ border: "1px solid #333", borderRadius: 6, padding: 10 }}>
+      <div style={{ fontSize: 12, color: "#94a3b8" }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 700, color }}>{value}</div>
+    </div>
+  );
+}
+
+type StatusProps = {
+  status?: string;
+  holographicActive?: boolean;
+  datasetSize: number;
+  busy?: boolean;
+};
+
+function StatusMessage({ status, holographicActive, datasetSize, busy }: StatusProps) {
+  const hints: string[] = [];
+  if (!holographicActive) {
+    hints.push("Activa el modo holográfico para capturar nuevas muestras.");
+  }
+  if (datasetSize === 0) {
+    hints.push("Captura al menos una configuración antes de entrenar.");
+  }
+  if (busy) {
+    hints.push("Procesando petición, por favor espera...");
+  }
+
+  return (
+    <div style={{ fontSize: 12, color: "#a0aec0", display: "grid", gap: 4 }}>
+      {status && <span>{status}</span>}
+      {hints.map((hint, index) => (
+        <span key={index} style={{ color: "#94a3b8" }}>
+          {hint}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default ReconstructionPanel;

--- a/src/ui/report.tsx
+++ b/src/ui/report.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  DEFAULT_BATCH_CONFIG,
+  REPORT_SUMMARY_KEYS,
+  formatExperimentCsv,
+  runBatchExperiments,
+  type ExperimentResult,
+  type ExperimentSummary,
+} from "../lib/experiments";
+
+function formatMeanStd(stats?: { mean: number; stdev: number }, digits = 3) {
+  if (!stats) return "–";
+  const mean = Number.isFinite(stats.mean) ? stats.mean.toFixed(digits) : "–";
+  const stdev = Number.isFinite(stats.stdev) ? stats.stdev.toFixed(digits) : "–";
+  return `${mean} ± ${stdev}`;
+}
+
+function clamp01(value: number) {
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+export function ReportPanel() {
+  const [results, setResults] = useState<ExperimentResult[]>([]);
+  const [summary, setSummary] = useState<ExperimentSummary | null>(null);
+  const [status, setStatus] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const handleRun = useCallback(async () => {
+    setStatus("running");
+    setError(null);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    try {
+      const { results, summary } = runBatchExperiments();
+      setResults(results);
+      setSummary(summary);
+      setStatus("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStatus("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !results.length) return;
+    const width = 360;
+    const height = 240;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.fillStyle = "#0f172a";
+    ctx.fillRect(0, 0, width, height);
+
+    const padding = 36;
+    ctx.strokeStyle = "#1e293b";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(padding, height - padding);
+    ctx.lineTo(width - padding, height - padding);
+    ctx.moveTo(padding, height - padding);
+    ctx.lineTo(padding, padding);
+    ctx.stroke();
+
+    ctx.fillStyle = "#64748b";
+    ctx.font = "12px Inter, sans-serif";
+    ctx.fillText("R² perímetro", width / 2 - 36, height - 8);
+    ctx.save();
+    ctx.translate(12, height / 2 + 24);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillText("R² área", 0, 0);
+    ctx.restore();
+
+    ctx.strokeStyle = "#334155";
+    ctx.beginPath();
+    ctx.moveTo(padding, height - padding);
+    ctx.lineTo(width - padding, padding);
+    ctx.stroke();
+
+    const plotWidth = width - padding * 2;
+    const plotHeight = height - padding * 2;
+    ctx.fillStyle = "rgba(129, 140, 248, 0.78)";
+    for (const item of results) {
+      const x = padding + plotWidth * clamp01(item.r2Perimeter);
+      const y = height - padding - plotHeight * clamp01(item.r2Area);
+      ctx.beginPath();
+      ctx.arc(x, y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    if (summary) {
+      const meanPerimeter = summary.metrics.r2Perimeter?.mean ?? 0;
+      const meanArea = summary.metrics.r2Area?.mean ?? 0;
+      const x = padding + plotWidth * clamp01(meanPerimeter);
+      const y = height - padding - plotHeight * clamp01(meanArea);
+      ctx.fillStyle = "#f97316";
+      ctx.beginPath();
+      ctx.arc(x, y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }, [results, summary]);
+
+  const summaryRows = useMemo(() => {
+    if (!summary) return [];
+    return REPORT_SUMMARY_KEYS.map(({ key, label }) => ({
+      key,
+      label,
+      stats: summary.metrics[key],
+    }));
+  }, [summary]);
+
+  const handleExport = useCallback(() => {
+    if (!results.length) return;
+    const csv = formatExperimentCsv(results);
+    const csvBlob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const csvUrl = URL.createObjectURL(csvBlob);
+    const csvLink = document.createElement("a");
+    csvLink.href = csvUrl;
+    csvLink.download = `reporte-experimentos-${Date.now()}.csv`;
+    csvLink.click();
+    URL.revokeObjectURL(csvUrl);
+
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const pngUrl = canvas.toDataURL("image/png");
+      const pngLink = document.createElement("a");
+      pngLink.href = pngUrl;
+      pngLink.download = `comparativa-area-volumen-${Date.now()}.png`;
+      pngLink.click();
+    }
+  }, [results]);
+
+  return (
+    <div className="bg-slate-900/80 rounded-2xl p-4 space-y-3">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Panel de resultados reproducibles</h2>
+          <p className="text-xs text-slate-400">
+            Barridos en depth, boundaryNoise y kernelMix (≥30 corridas). Configuración por defecto:
+            depth={DEFAULT_BATCH_CONFIG.depths.join(",")}, noise={DEFAULT_BATCH_CONFIG.boundaryNoises.join(",")},
+            kernelMix={DEFAULT_BATCH_CONFIG.kernelMixes.join(",")}, semillas={DEFAULT_BATCH_CONFIG.seeds.length}.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            className="px-3 py-1.5 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-sm disabled:opacity-40"
+            onClick={handleRun}
+            disabled={status === "running"}
+          >
+            {status === "running" ? "Calculando…" : "Correr experimentos"}
+          </button>
+          <button
+            className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm disabled:opacity-40"
+            onClick={handleExport}
+            disabled={!results.length}
+          >
+            Exportar reporte
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="text-sm text-rose-400">
+          Error al generar el reporte: {error}
+        </div>
+      )}
+
+      <canvas
+        ref={canvasRef}
+        className="w-full rounded-xl border border-slate-800"
+        aria-label="Comparativa R² perímetro vs R² área"
+      />
+
+      {summary && (
+        <div className="space-y-2 text-sm">
+          <div className="text-slate-300">
+            Corridas totales: <span className="font-semibold">{summary.totalRuns}</span>
+          </div>
+          <table className="w-full text-left text-xs border-separate border-spacing-y-1">
+            <thead>
+              <tr className="text-slate-400">
+                <th className="px-2">Métrica</th>
+                <th className="px-2">Media ± DE</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summaryRows.map(({ key, label, stats }) => (
+                <tr key={key} className="bg-slate-900/60">
+                  <td className="px-2 py-1.5 font-medium">{label}</td>
+                  <td className="px-2 py-1.5 text-slate-200">{formatMeanStd(stats)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {!summary && status === "done" && (
+        <div className="text-xs text-slate-400">No se encontraron datos para resumir.</div>
+      )}
+    </div>
+  );
+}
+
+export default ReportPanel;


### PR DESCRIPTION
## Summary
- ensure countClusters1D returns number of non-empty clusters by filtering out empty groups and counting final assignments
- document example usage demonstrating variable cluster counts

## Testing
- `npm test`
- `npx ts-node --compiler-options '{"module":"CommonJS"}' -e "const { countClusters1D } = require('./src/lib/resonance'); console.log('A', countClusters1D([0.1,0.15,0.8])); console.log('B', countClusters1D([0.1,0.15,0.2]));"`


------
https://chatgpt.com/codex/tasks/task_e_68c82e4ba780832089fe8bf62a2bacfa