### PR TITLE
Add Experimentos header button linking to documentation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,12 @@ export default function App(){
     URL.revokeObjectURL(url);
   };
 
+  const openExperimentsDoc = () => {
+    const experimentsUrl =
+      "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+    window.open(experimentsUrl, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 relative">
       <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
@@ -275,6 +281,7 @@ export default function App(){
           <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={resetAllHard}>Big Bang ♻︎</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={exportExcel}>Exportar CSV</button>
           <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={()=>exportGridPng("grid")}>Exportar captura</button>
+          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={openExperimentsDoc}>Experimentos</button>
         </div>
       </header>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { GlobalParamsPanel } from "./components/GlobalParamsPanel";
 import { KernelEditor } from "./components/KernelEditor";
 import ReportPanel from "./ui/report";
 import { ResonanceMeter } from "./components/ResonanceMeter";
+import { Header } from "./ui/Header";
+import { ExperimentsPanel } from "./ui/ExperimentsPanel";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
@@ -231,6 +233,7 @@ export default function App(){
   const [seeds, setSeeds] = useState<number[]>(() => Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
+  const [showExperimentsPanel, setShowExperimentsPanel] = useState(false);
 
   useEffect(() => {
     setSeeds(Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
@@ -272,18 +275,22 @@ export default function App(){
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 relative">
-      <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
-        <h1 className="text-xl sm:text-2xl font-bold text-center sm:text-left">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
-        <div className="flex flex-wrap justify-center sm:justify-end gap-2">
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={startAll}>Iniciar todo</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={pauseAll}>Pausar todo</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={resetAllSoft}>Reset 𝓣/R</button>
-          <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={resetAllHard}>Big Bang ♻︎</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={exportExcel}>Exportar CSV</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={()=>exportGridPng("grid")}>Exportar captura</button>
-          <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={openExperimentsDoc}>Experimentos</button>
+      <Header
+        onStartAll={startAll}
+        onPauseAll={pauseAll}
+        onResetSoft={resetAllSoft}
+        onResetHard={resetAllHard}
+        onExportCsv={exportExcel}
+        onExportCapture={() => exportGridPng("grid")}
+        onToggleExperiments={() => setShowExperimentsPanel((prev) => !prev)}
+        experimentsOpen={showExperimentsPanel}
+      />
+
+      {showExperimentsPanel && (
+        <div className="mb-4">
+          <ExperimentsPanel onOpenDoc={openExperimentsDoc} />
         </div>
-      </header>
+      )}
 
       <div className="flex flex-col lg:flex-row gap-4">
         <aside className="space-y-4 w-full lg:w-2/5">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ReportPanel from "./ui/report";
 import { ResonanceMeter } from "./components/ResonanceMeter";
 import { Header } from "./ui/Header";
 import { ExperimentsPanel } from "./ui/ExperimentsPanel";
+import { MetricsPanel } from "./ui/MetricsPanel";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
@@ -234,6 +235,7 @@ export default function App(){
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
   const [showExperimentsPanel, setShowExperimentsPanel] = useState(false);
+  const [showMetricsPanel, setShowMetricsPanel] = useState(false);
 
   useEffect(() => {
     setSeeds(Array.from({length: COUNT}, (_,i)=> baseSeed + i*7));
@@ -283,12 +285,15 @@ export default function App(){
         onExportCsv={exportExcel}
         onExportCapture={() => exportGridPng("grid")}
         onToggleExperiments={() => setShowExperimentsPanel((prev) => !prev)}
+        onToggleMetrics={() => setShowMetricsPanel((prev) => !prev)}
         experimentsOpen={showExperimentsPanel}
+        metricsOpen={showMetricsPanel}
       />
 
-      {showExperimentsPanel && (
-        <div className="mb-4">
-          <ExperimentsPanel onOpenDoc={openExperimentsDoc} />
+      {(showExperimentsPanel || showMetricsPanel) && (
+        <div className="space-y-4 mb-4">
+          {showMetricsPanel && <MetricsPanel seed={baseSeed} depth={gridSize} />}
+          {showExperimentsPanel && <ExperimentsPanel onOpenDoc={openExperimentsDoc} />}
         </div>
       )}
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -264,3 +264,15 @@ export function computeAreaLaw(
   };
 }
 
+
+export function getR2Perimeter(): number | null {
+  return null;
+}
+
+export function getR2Area(): number | null {
+  return null;
+}
+
+export function getBoundaryMode(): boolean | null {
+  return null;
+}

--- a/src/ui/ExperimentsPanel.tsx
+++ b/src/ui/ExperimentsPanel.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+
+type ExperimentsPanelProps = {
+  onOpenDoc: () => void;
+};
+
+const MAP_ROWS: Array<{ phi: string; lambda: string }> = [
+  { phi: "Fluctuaciones cuánticas del vacío", lambda: "Principio de incertidumbre (Heisenberg)" },
+  { phi: "Creación/aniquilación de pares partícula–antipartícula", lambda: "Conservación de energía y carga" },
+  { phi: "Oscilación de neutrinos", lambda: "Matriz PMNS (mezcla de sabores), masa mínima de neutrinos" },
+  { phi: "Reacciones nucleares (fusión, fisión)", lambda: "Fuerza nuclear fuerte y débil, barrera de Coulomb" },
+  { phi: "Tunelamiento cuántico", lambda: "Probabilidad cuántica, función de onda, no-clonación" },
+  { phi: "Formación de moléculas y enlaces químicos", lambda: "Constante de estructura fina (α), mecánica cuántica molecular" },
+  { phi: "Transiciones de fase (sólido–líquido–gas–plasma–BEC)", lambda: "Termodinámica (leyes de conservación, entropía)" },
+  { phi: "Actividad volcánica, tectónica y sísmica", lambda: "Física de materiales, gravedad, geodinámica" },
+  { phi: "Fenómenos atmosféricos (huracanes, auroras, arcoíris)", lambda: "Termodinámica, electromagnetismo, dinámica de fluidos" },
+  { phi: "Mutación y evolución biológica", lambda: "ADN, tasas de mutación, leyes de la selección natural" },
+  { phi: "Emergencia de conciencia", lambda: "Neurobiología, coherencia cuántica (hipótesis en debate)" },
+  { phi: "Muerte y regeneración parcial", lambda: "Límite de reparación celular, entropía biológica" },
+  { phi: "Formación de estrellas y planetas", lambda: "Colapso gravitatorio, límite de Jeans" },
+  { phi: "Supernovas, hipernovas, kilonovas", lambda: "Límite de Chandrasekhar, TOV" },
+  { phi: "Formación de agujeros negros", lambda: "Relatividad general, horizonte de eventos" },
+  { phi: "Evaporación de agujeros negros (Hawking)", lambda: "Mecánica cuántica + relatividad (aún no unificada)" },
+  { phi: "Colisiones galácticas", lambda: "Gravedad newtoniana/relativista, conservación de momento" },
+  { phi: "Ondas gravitacionales", lambda: "Relatividad general, energía gravitacional" },
+  { phi: "Expansión cósmica acelerada", lambda: "Constante cosmológica Λ, energía oscura" },
+  { phi: "Posible Big Bang e inflaciones", lambda: "Condiciones iniciales del universo, simetrías rotas" },
+  { phi: "Posibles universos burbuja", lambda: "Modelos inflacionarios multiverso" },
+  { phi: "Lenguaje, cultura, sociedades", lambda: "Neurociencia, evolución cognitiva, dinámica social" },
+  { phi: "Ciencia, arte, tecnología", lambda: "Límites de energía y recursos disponibles" },
+  { phi: "Computación e inteligencia artificial", lambda: "Teoría de la información, complejidad computacional" },
+  { phi: "Guerra y cooperación", lambda: "Psicología, sociología, recursos materiales" },
+  { phi: "Colonización espacial", lambda: "Ley de Tsiolkovsky, restricciones energéticas" },
+  { phi: "Ingeniería genética y biotecnología", lambda: "Biología molecular, bioética, límites mutacionales" },
+  { phi: "Ciborgs y transhumanismo", lambda: "Ingeniería biomédica, integración hombre-máquina" },
+  { phi: "Posible contacto extraterrestre", lambda: "Límites de detección (SETI, paradoja de Fermi)" },
+  { phi: "Colonización interestelar", lambda: "Relatividad especial (velocidad < c), energía finita" },
+];
+
+export function ExperimentsPanel({ onOpenDoc }: ExperimentsPanelProps) {
+  return (
+    <section className="bg-slate-900/80 border border-slate-800 rounded-2xl p-4 space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Mapa Φ ∘ 𝓛(x)</h2>
+        <p className="text-sm text-slate-400">Sucesos potenciales frente a estructuras limitantes.</p>
+      </header>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm border-separate border-spacing-y-1 min-w-[480px]">
+          <thead>
+            <tr className="text-slate-400">
+              <th className="px-3 py-2 w-1/2">Φ — Sucesos y hechos posibles</th>
+              <th className="px-3 py-2 w-1/2">𝓛 — Estructuras limitantes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {MAP_ROWS.map((row) => (
+              <tr key={`${row.phi}-${row.lambda}`} className="bg-slate-900/60 align-top">
+                <td className="px-3 py-2 text-slate-200">{row.phi}</td>
+                <td className="px-3 py-2 text-slate-200">{row.lambda}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <section className="space-y-2 text-sm text-slate-200">
+        <h3 className="text-sm font-semibold text-slate-300">Interpretación (Φ, 𝓛, R)</h3>
+        <p>
+          <strong className="text-slate-100">Φ</strong> representa el abanico de sucesos posibles, desde procesos cuánticos hasta
+          fenómenos sociales y tecnológicos.
+        </p>
+        <p>
+          <strong className="text-slate-100">𝓛</strong> describe las leyes, constantes y límites que estructuran o restringen esos
+          sucesos, determinando qué potencialidades pueden manifestarse.
+        </p>
+        <p>
+          La realidad <strong className="text-slate-100">R</strong> emerge donde ambas columnas coinciden: cuando un suceso posible
+          cumple las condiciones limitantes, se actualiza como evento concreto sin alterar el motor holográfico.
+        </p>
+      </section>
+
+      <div className="flex justify-end">
+        <button
+          className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm"
+          onClick={onOpenDoc}
+          type="button"
+        >
+          Abrir en GitHub
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -8,7 +8,9 @@ type HeaderProps = {
   onExportCsv: () => void;
   onExportCapture: () => void;
   onToggleExperiments: () => void;
+  onToggleMetrics: () => void;
   experimentsOpen: boolean;
+  metricsOpen: boolean;
 };
 
 export function Header({
@@ -19,11 +21,14 @@ export function Header({
   onExportCsv,
   onExportCapture,
   onToggleExperiments,
+  onToggleMetrics,
   experimentsOpen,
+  metricsOpen,
 }: HeaderProps) {
-  const experimentsButtonClassName = experimentsOpen
-    ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
-    : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
+  const toggleButtonClassName = (isActive: boolean) =>
+    isActive
+      ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
+      : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
 
   return (
     <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
@@ -48,7 +53,15 @@ export function Header({
           Exportar captura
         </button>
         <button
-          className={experimentsButtonClassName}
+          className={toggleButtonClassName(metricsOpen)}
+          onClick={onToggleMetrics}
+          aria-pressed={metricsOpen}
+          type="button"
+        >
+          {metricsOpen ? "Cerrar métricas" : "Métricas básicas"}
+        </button>
+        <button
+          className={toggleButtonClassName(experimentsOpen)}
           onClick={onToggleExperiments}
           aria-pressed={experimentsOpen}
           type="button"

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+type HeaderProps = {
+  onStartAll: () => void;
+  onPauseAll: () => void;
+  onResetSoft: () => void;
+  onResetHard: () => void;
+  onExportCsv: () => void;
+  onExportCapture: () => void;
+  onToggleExperiments: () => void;
+  experimentsOpen: boolean;
+};
+
+export function Header({
+  onStartAll,
+  onPauseAll,
+  onResetSoft,
+  onResetHard,
+  onExportCsv,
+  onExportCapture,
+  onToggleExperiments,
+  experimentsOpen,
+}: HeaderProps) {
+  const experimentsButtonClassName = experimentsOpen
+    ? "px-3 py-1 rounded-xl bg-emerald-600 hover:bg-emerald-500"
+    : "px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700";
+
+  return (
+    <header className="flex flex-col sm:flex-row items-center justify-between mb-4 gap-2">
+      <h1 className="text-xl sm:text-2xl font-bold text-center sm:text-left">BigBangSim — Φ ∘ 𝓛(x) → R</h1>
+      <div className="flex flex-wrap justify-center sm:justify-end gap-2">
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onStartAll}>
+          Iniciar todo
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onPauseAll}>
+          Pausar todo
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onResetSoft}>
+          Reset 𝓣/R
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-indigo-700 hover:bg-indigo-600" onClick={onResetHard}>
+          Big Bang ♻︎
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onExportCsv}>
+          Exportar CSV
+        </button>
+        <button className="px-3 py-1 rounded-xl bg-slate-800 hover:bg-slate-700" onClick={onExportCapture}>
+          Exportar captura
+        </button>
+        <button
+          className={experimentsButtonClassName}
+          onClick={onToggleExperiments}
+          aria-pressed={experimentsOpen}
+          type="button"
+        >
+          {experimentsOpen ? "Cerrar mapa Φ ∘ 𝓛(x)" : "Mapa Φ ∘ 𝓛(x)"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/ui/MetricsPanel.tsx
+++ b/src/ui/MetricsPanel.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { getBoundaryMode, getR2Area, getR2Perimeter } from "../metrics";
+
+type MetricsPanelProps = {
+  seed?: number | string | null;
+  depth?: number | string | null;
+};
+
+function formatR2(value: number | null): string {
+  if (value == null) {
+    return "N/D";
+  }
+  return value.toFixed(3);
+}
+
+function formatBoundary(value: boolean | null): string {
+  if (value == null) {
+    return "N/D";
+  }
+  return value ? "ON" : "OFF";
+}
+
+function formatScalar(value: number | string | null | undefined): string {
+  if (value === null || value === undefined || value === "") {
+    return "N/D";
+  }
+  return typeof value === "number" ? value.toString() : value;
+}
+
+export function MetricsPanel({ seed, depth }: MetricsPanelProps) {
+  const r2Perimeter = getR2Perimeter();
+  const r2Area = getR2Area();
+  const boundaryMode = getBoundaryMode();
+
+  const handleExport = () => {
+    const timestamp = new Date().toISOString();
+    const rows = [
+      "seed,depth,R2_perimeter,R2_area,timestamp",
+      [
+        formatScalar(seed),
+        formatScalar(depth),
+        r2Perimeter != null ? r2Perimeter.toString() : "N/D",
+        r2Area != null ? r2Area.toString() : "N/D",
+        timestamp,
+      ].join(","),
+    ];
+
+    const blob = new Blob([rows.join("\n")], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `metricas-experimentos-${timestamp.replace(/[:.]/g, "-")}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <section className="bg-slate-900/80 border border-slate-800 rounded-2xl p-4 space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">Métricas básicas</h2>
+        <p className="text-sm text-slate-400">Lectura de indicadores actuales del sistema.</p>
+      </header>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">R² (perímetro)</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatR2(r2Perimeter)}</div>
+        </div>
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">R² (área)</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatR2(r2Area)}</div>
+        </div>
+        <div className="bg-slate-900/60 rounded-xl p-3 border border-slate-800/60">
+          <div className="text-xs uppercase tracking-wide text-slate-400">Boundary Mode</div>
+          <div className="text-2xl font-semibold text-slate-100">{formatBoundary(boundaryMode)}</div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 text-sm text-slate-300">
+        <div className="bg-slate-900/40 rounded-xl p-3 border border-slate-800/40">
+          <div className="text-xs uppercase tracking-wide text-slate-500">Seed base</div>
+          <div className="text-base text-slate-100">{formatScalar(seed)}</div>
+        </div>
+        <div className="bg-slate-900/40 rounded-xl p-3 border border-slate-800/40">
+          <div className="text-xs uppercase tracking-wide text-slate-500">Profundidad (depth)</div>
+          <div className="text-base text-slate-100">{formatScalar(depth)}</div>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm"
+          onClick={handleExport}
+          type="button"
+        >
+          Exportar CSV (experimentos)
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an Experimentos action in the top bar that opens the experiments documentation in a new tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad6dd63e88320ac48f0aad9bf4b35