### PR TITLE
Add physics registry with validation and adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida d
 Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Abrir en GitHub"** del panel de experimentos creando un archivo `.env` en la raíz con:
 
 ```bash
-VITE_EXPERIMENTS_DOC_URL="https://github.com/<usuario>/<repo>/blob/main/docs/README-Experimentos.md"
+VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/neon.r/blob/main/docs/README-Experimentos.md"
 ```
 
 Al omitir la variable, la aplicación conserva el enlace predeterminado a la documentación de este repositorio (`SOLIS-Lab/SOLIS-BigBang-Demo`).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ De esta forma la atenuación de cada tic solo afecta al campo de potenciales Φ,
 
 Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida de los experimentos, consulta [docs/README-Experimentos.md](docs/README-Experimentos.md).
 
+### Personalizar el enlace de documentación de experimentos
+
+Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Abrir en GitHub"** del panel de experimentos creando un archivo `.env` en la raíz con:
+
+```bash
+VITE_EXPERIMENTS_DOC_URL="https://github.com/<usuario>/<repo>/blob/main/docs/README-Experimentos.md"
+```
+
+Al omitir la variable, la aplicación conserva el enlace predeterminado a la documentación de este repositorio (`SOLIS-Lab/SOLIS-BigBang-Demo`).
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida d
 Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Axiomas"** del panel de experimentos creando un archivo `.env` en la raíz con:
 
 ```bash
-VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf"
+VITE_EXPERIMENTS_DOC_URL="https://zenodo.org/records/15793537"
 ```
 
-Usa siempre direcciones completas que comiencen con `https://` o `http://` (por ejemplo, un PDF alojado en GitHub o Zenodo); cualquier valor relativo o sin protocolo se descartará y el botón volverá al enlace predeterminado al compendio de axiomas de este repositorio (`docs/axiomas.pdf`).
+Usa siempre direcciones completas que comiencen con `https://` o `http://` (por ejemplo, un PDF alojado en GitHub o Zenodo); cualquier valor relativo o sin protocolo se descartará y el botón volverá al enlace predeterminado alojado en Zenodo (`https://zenodo.org/records/15793537`).
 
 En entornos desplegados con `server.js` (por ejemplo, Railway) también puedes definir la variable de entorno `EXPERIMENTS_DOC_URL` para ajustar la URL en tiempo de ejecución sin reconstruir el bundle. Si ambas (`VITE_EXPERIMENTS_DOC_URL` y `EXPERIMENTS_DOC_URL`) están presentes, el valor en tiempo de ejecución tiene prioridad al renderizar la aplicación.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/neon.r/blob/main/
 
 Al omitir la variable, la aplicación conserva el enlace predeterminado a la documentación de este repositorio (`SOLIS-Lab/SOLIS-BigBang-Demo`).
 
+En entornos desplegados con `server.js` (por ejemplo, Railway) también puedes definir la variable de entorno `EXPERIMENTS_DOC_URL` para ajustar la URL en tiempo de ejecución sin reconstruir el bundle. Si ambas (`VITE_EXPERIMENTS_DOC_URL` y `EXPERIMENTS_DOC_URL`) están presentes, el valor en tiempo de ejecución tiene prioridad al renderizar la aplicación.
+
 ## Licencias
 - El código fuente se distribuye bajo la [Licencia Apache 2.0](LICENSE).
 - La documentación y axiomas incluidos en `docs/` se distribuyen bajo la licencia [CC BY-NC-ND 4.0](docs/LICENSE-docs-CC-BY-NC-ND-4.0.md).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Si publicas el simulador desde un repositorio distinto, puedes definir la URL qu
 VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf"
 ```
 
-Al omitir la variable, la aplicación conserva el enlace predeterminado al compendio de axiomas de este repositorio (`docs/axiomas.pdf`).
+Usa siempre direcciones completas que comiencen con `https://` o `http://` (por ejemplo, un PDF alojado en GitHub o Zenodo); cualquier valor relativo o sin protocolo se descartará y el botón volverá al enlace predeterminado al compendio de axiomas de este repositorio (`docs/axiomas.pdf`).
 
 En entornos desplegados con `server.js` (por ejemplo, Railway) también puedes definir la variable de entorno `EXPERIMENTS_DOC_URL` para ajustar la URL en tiempo de ejecución sin reconstruir el bundle. Si ambas (`VITE_EXPERIMENTS_DOC_URL` y `EXPERIMENTS_DOC_URL`) están presentes, el valor en tiempo de ejecución tiene prioridad al renderizar la aplicación.
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida d
 Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Axiomas"** del panel de experimentos creando un archivo `.env` en la raíz con:
 
 ```bash
-VITE_EXPERIMENTS_DOC_URL="https://zenodo.org/records/15793537"
+VITE_EXPERIMENTS_DOC_URL="https://zenodo.org/records/17153982"
 ```
 
-Usa siempre direcciones completas que comiencen con `https://` o `http://` (por ejemplo, un PDF alojado en GitHub o Zenodo); cualquier valor relativo o sin protocolo se descartará y el botón volverá al enlace predeterminado alojado en Zenodo (`https://zenodo.org/records/15793537`).
+Usa siempre direcciones completas que comiencen con `https://` o `http://` (por ejemplo, un PDF alojado en GitHub o Zenodo); cualquier valor relativo o sin protocolo se descartará y el botón volverá al enlace predeterminado alojado en Zenodo (`https://zenodo.org/records/17153982`).
 
 En entornos desplegados con `server.js` (por ejemplo, Railway) también puedes definir la variable de entorno `EXPERIMENTS_DOC_URL` para ajustar la URL en tiempo de ejecución sin reconstruir el bundle. Si ambas (`VITE_EXPERIMENTS_DOC_URL` y `EXPERIMENTS_DOC_URL`) están presentes, el valor en tiempo de ejecución tiene prioridad al renderizar la aplicación.
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Para el inventario metaontológico (Φ–𝓛) y la guía conceptual extendida d
 
 ### Personalizar el enlace de documentación de experimentos
 
-Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Abrir en GitHub"** del panel de experimentos creando un archivo `.env` en la raíz con:
+Si publicas el simulador desde un repositorio distinto, puedes definir la URL que abre el botón **"Axiomas"** del panel de experimentos creando un archivo `.env` en la raíz con:
 
 ```bash
-VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/neon.r/blob/main/docs/README-Experimentos.md"
+VITE_EXPERIMENTS_DOC_URL="https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf"
 ```
 
-Al omitir la variable, la aplicación conserva el enlace predeterminado a la documentación de este repositorio (`SOLIS-Lab/SOLIS-BigBang-Demo`).
+Al omitir la variable, la aplicación conserva el enlace predeterminado al compendio de axiomas de este repositorio (`docs/axiomas.pdf`).
 
 En entornos desplegados con `server.js` (por ejemplo, Railway) también puedes definir la variable de entorno `EXPERIMENTS_DOC_URL` para ajustar la URL en tiempo de ejecución sin reconstruir el bundle. Si ambas (`VITE_EXPERIMENTS_DOC_URL` y `EXPERIMENTS_DOC_URL`) están presentes, el valor en tiempo de ejecución tiene prioridad al renderizar la aplicación.
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo 'No tests defined' && exit 0",
+    "test": "rm -rf .tmp-tests && tsc --project tsconfig.test.json && node .tmp-tests/tests/config.test.mjs",
     "postinstall": "npm run build"
   },
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const DEFAULT_EXPERIMENTS_DOC_URL =
-  'https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md';
+  'https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf';
 
 app.use(compression());
 app.use(express.json());

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const DEFAULT_EXPERIMENTS_DOC_URL = 'https://zenodo.org/records/15793537';
+const DEFAULT_EXPERIMENTS_DOC_URL = 'https://zenodo.org/records/17153982';
 
 app.use(compression());
 app.use(express.json());

--- a/server.js
+++ b/server.js
@@ -33,10 +33,15 @@ if (fs.existsSync(indexFilePath)) {
   cachedIndexHtml = fs.readFileSync(indexFilePath, 'utf8');
 }
 
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
 function resolveRuntimeExperimentsDocUrl() {
   const envValue =
     process.env.EXPERIMENTS_DOC_URL ?? process.env.VITE_EXPERIMENTS_DOC_URL ?? '';
   const trimmed = envValue.trim();
+  if (!trimmed || !HTTP_URL_PATTERN.test(trimmed)) {
+    return '';
+  }
   return trimmed;
 }
 

--- a/server.js
+++ b/server.js
@@ -6,6 +6,8 @@ const fs = require('fs');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const DEFAULT_EXPERIMENTS_DOC_URL =
+  'https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md';
 
 app.use(compression());
 app.use(express.json());
@@ -23,16 +25,53 @@ app.get('/debug', (_req, res) => {
   res.json({ distPath, indexExists: exists, listing });
 });
 
-app.use(express.static(distPath, { maxAge: '1h', etag: true }));
+app.use(express.static(distPath, { maxAge: '1h', etag: true, index: false }));
+
+const indexFilePath = path.join(distPath, 'index.html');
+let cachedIndexHtml = null;
+if (fs.existsSync(indexFilePath)) {
+  cachedIndexHtml = fs.readFileSync(indexFilePath, 'utf8');
+}
+
+function resolveRuntimeExperimentsDocUrl() {
+  const envValue =
+    process.env.EXPERIMENTS_DOC_URL ?? process.env.VITE_EXPERIMENTS_DOC_URL ?? '';
+  const trimmed = envValue.trim();
+  return trimmed;
+}
+
+function serializeForInlineScript(obj) {
+  return JSON.stringify(obj).replace(/</g, '\\u003c');
+}
 
 app.get('*', (req, res) => {
   if (req.path.startsWith('/api/')) return res.status(404).end();
-  const indexFile = path.join(distPath, 'index.html');
-  if (!fs.existsSync(indexFile)) {
-    console.error('[ERROR] index.html no encontrado en:', indexFile);
-    return res.status(500).send('Build no encontrado. ¿Corrió "npm run build"?');
+
+  if (!cachedIndexHtml) {
+    if (!fs.existsSync(indexFilePath)) {
+      console.error('[ERROR] index.html no encontrado en:', indexFilePath);
+      return res
+        .status(500)
+        .send('Build no encontrado. ¿Corrió "npm run build"?');
+    }
+    cachedIndexHtml = fs.readFileSync(indexFilePath, 'utf8');
   }
-  res.sendFile(indexFile);
+
+  const runtimeUrl = resolveRuntimeExperimentsDocUrl();
+  const effectiveUrl = runtimeUrl || DEFAULT_EXPERIMENTS_DOC_URL;
+  const runtimeScript = `<script>window.__BB_RUNTIME_CONFIG__ = Object.assign({}, window.__BB_RUNTIME_CONFIG__, ${serializeForInlineScript({
+    experimentsDocUrl: effectiveUrl,
+  })});</script>`;
+
+  let htmlToSend = cachedIndexHtml;
+  if (cachedIndexHtml.includes('</body>')) {
+    htmlToSend = cachedIndexHtml.replace('</body>', `${runtimeScript}\n</body>`);
+  } else {
+    htmlToSend = `${cachedIndexHtml}\n${runtimeScript}`;
+  }
+
+  res.setHeader('Content-Type', 'text/html');
+  res.send(htmlToSend);
 });
 
 app.use((err, _req, res, _next) => {

--- a/server.js
+++ b/server.js
@@ -6,8 +6,7 @@ const fs = require('fs');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const DEFAULT_EXPERIMENTS_DOC_URL =
-  'https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf';
+const DEFAULT_EXPERIMENTS_DOC_URL = 'https://zenodo.org/records/15793537';
 
 app.use(compression());
 app.use(express.json());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,14 @@ import { MetricsPanel } from "./ui/MetricsPanel";
 import { ParamsPanel } from "./ui/ParamsPanel";
 import type { EngineAdapterResult } from "./lib/physics/adapters";
 import type { ExperimentHints } from "./lib/bridge";
-
-const DEFAULT_EXPERIMENTS_DOC_URL =
-  "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+import { getExperimentsDocUrl } from "./config";
 
 declare global {
   interface Window {
     __BB_EXPERIMENT_HINTS__?: ExperimentHints | null;
+    __BB_RUNTIME_CONFIG__?: {
+      experimentsDocUrl?: string | null;
+    };
   }
 }
 
@@ -312,9 +313,7 @@ export default function App(){
   };
 
   const openExperimentsDoc = () => {
-    const experimentsUrl =
-      (import.meta.env.VITE_EXPERIMENTS_DOC_URL ?? "").trim() ||
-      DEFAULT_EXPERIMENTS_DOC_URL;
+    const experimentsUrl = getExperimentsDocUrl();
     window.open(experimentsUrl, "_blank", "noopener,noreferrer");
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,9 @@ import { ParamsPanel } from "./ui/ParamsPanel";
 import type { EngineAdapterResult } from "./lib/physics/adapters";
 import type { ExperimentHints } from "./lib/bridge";
 
+const DEFAULT_EXPERIMENTS_DOC_URL =
+  "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+
 declare global {
   interface Window {
     __BB_EXPERIMENT_HINTS__?: ExperimentHints | null;
@@ -310,7 +313,8 @@ export default function App(){
 
   const openExperimentsDoc = () => {
     const experimentsUrl =
-      "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+      (import.meta.env.VITE_EXPERIMENTS_DOC_URL ?? "").trim() ||
+      DEFAULT_EXPERIMENTS_DOC_URL;
     window.open(experimentsUrl, "_blank", "noopener,noreferrer");
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { ResonanceMeter } from "./components/ResonanceMeter";
 import { Header } from "./ui/Header";
 import { ExperimentsPanel } from "./ui/ExperimentsPanel";
 import { MetricsPanel } from "./ui/MetricsPanel";
+import { ParamsPanel } from "./ui/ParamsPanel";
+import type { EngineAdapterResult } from "./lib/physics/adapters";
 
 // ==== Core types reproduced to remain compatible with BigBang2 motor ====
 type Possibility = { id: string; energy: number; symmetry: number; curvature: number; phase: number; };
@@ -235,6 +237,9 @@ export default function App(){
   const [running, setRunning] = useState<boolean[]>(() => Array.from({length: COUNT}, ()=> true));
   const [resetSignals, setResetSignals] = useState<number[]>(() => Array.from({length: COUNT}, ()=> 0));
   const [showExperimentsPanel, setShowExperimentsPanel] = useState(false);
+  const [showParamsPanel, setShowParamsPanel] = useState(false);
+  const [appliedEngineSuggestions, setAppliedEngineSuggestions] =
+    useState<EngineAdapterResult | null>(null);
   const [showMetricsPanel, setShowMetricsPanel] = useState(false);
 
   useEffect(() => {
@@ -286,12 +291,20 @@ export default function App(){
         onExportCapture={() => exportGridPng("grid")}
         onToggleExperiments={() => setShowExperimentsPanel((prev) => !prev)}
         onToggleMetrics={() => setShowMetricsPanel((prev) => !prev)}
+        onToggleParams={() => setShowParamsPanel((prev) => !prev)}
         experimentsOpen={showExperimentsPanel}
         metricsOpen={showMetricsPanel}
+        paramsOpen={showParamsPanel}
       />
 
-      {(showExperimentsPanel || showMetricsPanel) && (
+      {(showExperimentsPanel || showMetricsPanel || showParamsPanel) && (
         <div className="space-y-4 mb-4">
+          {showParamsPanel && (
+            <ParamsPanel
+              onApplySuggestions={(result) => setAppliedEngineSuggestions(result)}
+              lastAppliedResult={appliedEngineSuggestions}
+            />
+          )}
           {showMetricsPanel && <MetricsPanel seed={baseSeed} depth={gridSize} />}
           {showExperimentsPanel && <ExperimentsPanel onOpenDoc={openExperimentsDoc} />}
         </div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,59 @@
+export const DEFAULT_EXPERIMENTS_DOC_URL =
+  "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+
+type MaybeString = string | null | undefined;
+
+const PLACEHOLDER_PATTERN = /^__BB_EXPERIMENTS_DOC_URL__$/;
+
+function normalizeCandidate(value: MaybeString): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || PLACEHOLDER_PATTERN.test(trimmed)) {
+    return "";
+  }
+  return trimmed;
+}
+
+function readRuntimeConfig(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const runtime = window.__BB_RUNTIME_CONFIG__;
+  if (!runtime) {
+    return "";
+  }
+  return normalizeCandidate(runtime.experimentsDocUrl ?? "");
+}
+
+function readViteEnv(): string {
+  const viteValue = normalizeCandidate(
+    (import.meta.env.VITE_EXPERIMENTS_DOC_URL as MaybeString) ?? ""
+  );
+  return viteValue;
+}
+
+export function getExperimentsDocUrl(): string {
+  const fromVite = readViteEnv();
+  if (fromVite) {
+    return fromVite;
+  }
+
+  const fromRuntime = readRuntimeConfig();
+  if (fromRuntime) {
+    return fromRuntime;
+  }
+
+  return DEFAULT_EXPERIMENTS_DOC_URL;
+}
+
+declare global {
+  interface Window {
+    __BB_RUNTIME_CONFIG__?: {
+      experimentsDocUrl?: string | null;
+    };
+  }
+}
+
+export {}; // ensure this file is treated as a module

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_EXPERIMENTS_DOC_URL =
-  "https://github.com/SOLIS-Lab/SOLIS-BigBang-Demo/blob/main/docs/README-Experimentos.md";
+  "https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf";
 
 type MaybeString = string | null | undefined;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ export const DEFAULT_EXPERIMENTS_DOC_URL =
 type MaybeString = string | null | undefined;
 
 const PLACEHOLDER_PATTERN = /^__BB_EXPERIMENTS_DOC_URL__$/;
+const HTTP_URL_PATTERN = /^https?:\/\//i;
 
 function normalizeCandidate(value: MaybeString): string {
   if (typeof value !== "string") {
@@ -11,6 +12,10 @@ function normalizeCandidate(value: MaybeString): string {
   }
   const trimmed = value.trim();
   if (!trimmed || PLACEHOLDER_PATTERN.test(trimmed)) {
+    return "";
+  }
+
+  if (!HTTP_URL_PATTERN.test(trimmed)) {
     return "";
   }
   return trimmed;

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,21 +28,28 @@ function readRuntimeConfig(): string {
 }
 
 function readViteEnv(): string {
+  const env = (
+    (import.meta as ImportMeta & {
+      env?: Record<string, unknown>;
+    })
+  ).env ?? (globalThis as { __BB_IMPORT_META_ENV__?: Record<string, unknown> })
+    .__BB_IMPORT_META_ENV__;
+
   const viteValue = normalizeCandidate(
-    (import.meta.env.VITE_EXPERIMENTS_DOC_URL as MaybeString) ?? ""
+    (env?.VITE_EXPERIMENTS_DOC_URL as MaybeString) ?? ""
   );
   return viteValue;
 }
 
 export function getExperimentsDocUrl(): string {
-  const fromVite = readViteEnv();
-  if (fromVite) {
-    return fromVite;
-  }
-
   const fromRuntime = readRuntimeConfig();
   if (fromRuntime) {
     return fromRuntime;
+  }
+
+  const fromVite = readViteEnv();
+  if (fromVite) {
+    return fromVite;
   }
 
   return DEFAULT_EXPERIMENTS_DOC_URL;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_EXPERIMENTS_DOC_URL =
-  "https://zenodo.org/records/15793537";
+  "https://zenodo.org/records/17153982";
 
 type MaybeString = string | null | undefined;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_EXPERIMENTS_DOC_URL =
-  "https://github.com/alejandrosolis907/SOLIS-BigBang-Demo/blob/main/docs/axiomas.pdf";
+  "https://zenodo.org/records/15793537";
 
 type MaybeString = string | null | undefined;
 

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -1,0 +1,305 @@
+export interface ExperimentHints {
+  readonly noise?: number | null;
+  readonly damping?: number | null;
+  readonly kernel?: string | null;
+}
+
+interface BaselineSnapshot {
+  noise?: number;
+  damping?: number;
+  kernelMix?: number;
+  preset?: string | null;
+}
+
+interface AppliedSnapshot {
+  noise: number | null;
+  damping: number | null;
+  kernel: string | null;
+}
+
+interface BridgeRecord {
+  baseline: BaselineSnapshot;
+  applied: AppliedSnapshot;
+}
+
+const STATE_RECORD = new WeakMap<object, BridgeRecord>();
+
+const KERNEL_HINT_MAP: Record<string, { preset?: string; kernelMix?: number; useBaselinePreset?: boolean }> = {
+  gaussian: { preset: "smooth", kernelMix: 0 },
+  lorentzian: { preset: "rigid", kernelMix: 1 },
+  wave: { preset: "entropy", kernelMix: 0.5 },
+  exponential: { preset: "smooth", kernelMix: 0.3 },
+  adaptive: { kernelMix: 0.6, useBaselinePreset: true },
+};
+
+const NUMERIC_SETTERS: Record<string, readonly string[]> = {
+  noise: ["setNoise", "setBoundaryNoise", "setBalance"],
+  damping: ["setDamping", "setMu", "setFriction"],
+  kernelMix: ["setKernelMix", "setBoundaryKernelMix"],
+};
+
+const NUMERIC_PROPERTIES: Record<string, readonly string[]> = {
+  noise: ["drift", "noise", "boundaryNoise", "balance"],
+  damping: ["mu", "damping", "friction"],
+  kernelMix: ["kernelMix", "boundaryKernelMix"],
+};
+
+const STRING_SETTERS: Record<string, readonly string[]> = {
+  kernel: ["setKernel", "setPreset", "setKernelPreset"],
+};
+
+const STRING_PROPERTIES: Record<string, readonly string[]> = {
+  kernel: ["preset", "kernelPreset"],
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+function callSetter(target: Record<string, unknown>, names: readonly string[], value: unknown): boolean {
+  for (const name of names) {
+    const candidate = target[name];
+    if (typeof candidate === "function") {
+      try {
+        (candidate as (next: unknown) => void).call(target, value);
+        return true;
+      } catch (error) {
+        // ignore setter errors to avoid breaking simulation loop
+      }
+    }
+  }
+  return false;
+}
+
+function assignNumeric(
+  target: Record<string, unknown>,
+  names: readonly string[],
+  value: number | undefined,
+): void {
+  if (value === undefined) {
+    for (const name of names) {
+      if (Object.prototype.hasOwnProperty.call(target, name)) {
+        delete (target as Record<string, unknown>)[name];
+        return;
+      }
+    }
+    return;
+  }
+  for (const name of names) {
+    if (Object.prototype.hasOwnProperty.call(target, name)) {
+      (target as Record<string, unknown>)[name] = value;
+      return;
+    }
+  }
+  if (names.length) {
+    (target as Record<string, unknown>)[names[0]] = value;
+  }
+}
+
+function assignString(
+  target: Record<string, unknown>,
+  names: readonly string[],
+  value: string | undefined | null,
+): void {
+  if (!value) {
+    for (const name of names) {
+      if (Object.prototype.hasOwnProperty.call(target, name)) {
+        delete (target as Record<string, unknown>)[name];
+        return;
+      }
+    }
+    return;
+  }
+  for (const name of names) {
+    if (Object.prototype.hasOwnProperty.call(target, name)) {
+      (target as Record<string, unknown>)[name] = value;
+      return;
+    }
+  }
+  if (names.length) {
+    (target as Record<string, unknown>)[names[0]] = value;
+  }
+}
+
+function updateNumericValue(
+  state: Record<string, unknown>,
+  kind: keyof typeof NUMERIC_SETTERS,
+  value: number | undefined,
+): void {
+  const setters = NUMERIC_SETTERS[kind] ?? [];
+  const properties = NUMERIC_PROPERTIES[kind] ?? [];
+  if (value === undefined) {
+    if (!callSetter(state, setters, undefined)) {
+      assignNumeric(state, properties, undefined);
+    }
+    return;
+  }
+  if (!callSetter(state, setters, value)) {
+    assignNumeric(state, properties, value);
+  }
+}
+
+function updateStringValue(
+  state: Record<string, unknown>,
+  kind: keyof typeof STRING_SETTERS,
+  value: string | null,
+): void {
+  const setters = STRING_SETTERS[kind] ?? [];
+  const properties = STRING_PROPERTIES[kind] ?? [];
+  if (!value) {
+    if (!callSetter(state, setters, undefined)) {
+      assignString(state, properties, undefined);
+    }
+    return;
+  }
+  if (!callSetter(state, setters, value)) {
+    assignString(state, properties, value);
+  }
+}
+
+function readNoise(state: Record<string, unknown>): number | undefined {
+  if (isFiniteNumber(state.drift)) return state.drift;
+  if (isFiniteNumber(state.noise)) return state.noise;
+  if (isFiniteNumber(state.boundaryNoise)) return state.boundaryNoise;
+  if (isFiniteNumber(state.balance)) return state.balance;
+  return undefined;
+}
+
+function readDamping(state: Record<string, unknown>): number | undefined {
+  if (isFiniteNumber(state.mu)) return state.mu;
+  if (isFiniteNumber(state.damping)) return state.damping;
+  if (isFiniteNumber(state.friction)) return state.friction;
+  return undefined;
+}
+
+function readKernelMix(state: Record<string, unknown>): number | undefined {
+  if (isFiniteNumber(state.kernelMix)) return state.kernelMix;
+  if (isFiniteNumber(state.boundaryKernelMix)) return state.boundaryKernelMix;
+  return undefined;
+}
+
+function readKernelPreset(state: Record<string, unknown>): string | undefined {
+  if (typeof state.preset === "string" && state.preset) return state.preset;
+  if (typeof state.kernelPreset === "string" && state.kernelPreset) return state.kernelPreset;
+  return undefined;
+}
+
+function applyKernelMapping(
+  state: Record<string, unknown>,
+  kernel: string,
+  baseline: BaselineSnapshot,
+): void {
+  const mapping = KERNEL_HINT_MAP[kernel];
+  if (!mapping) return;
+
+  if (typeof mapping.kernelMix === "number") {
+    updateNumericValue(state, "kernelMix", clamp01(mapping.kernelMix));
+  }
+
+  if (mapping.preset) {
+    updateStringValue(state, "kernel", mapping.preset);
+  } else if (mapping.useBaselinePreset && baseline.preset) {
+    updateStringValue(state, "kernel", baseline.preset);
+  }
+}
+
+function ensureRecord(state: Record<string, unknown>): BridgeRecord {
+  let record = STATE_RECORD.get(state);
+  if (!record) {
+    record = {
+      baseline: {
+        noise: readNoise(state),
+        damping: readDamping(state),
+        kernelMix: readKernelMix(state),
+        preset: readKernelPreset(state) ?? null,
+      },
+      applied: { noise: null, damping: null, kernel: null },
+    };
+    STATE_RECORD.set(state, record);
+  }
+  return record;
+}
+
+function normalizeHints(hints: ExperimentHints | null | undefined): AppliedSnapshot {
+  const noise = hints?.noise;
+  const damping = hints?.damping;
+  const kernel = hints?.kernel;
+  return {
+    noise: isFiniteNumber(noise) ? noise : null,
+    damping: isFiniteNumber(damping) ? damping : null,
+    kernel: typeof kernel === "string" && kernel.trim() ? kernel.trim().toLowerCase() : null,
+  };
+}
+
+export function applyExperimentHints(
+  state: Record<string, unknown> | null | undefined,
+  hints: ExperimentHints | null | undefined,
+): void {
+  if (!state) return;
+
+  const record = ensureRecord(state);
+  const normalized = normalizeHints(hints);
+
+  // Track baseline when no hint is active.
+  if (normalized.noise === null && record.applied.noise === null) {
+    record.baseline.noise = readNoise(state);
+  }
+  if (normalized.damping === null && record.applied.damping === null) {
+    record.baseline.damping = readDamping(state);
+  }
+  if (normalized.kernel === null && record.applied.kernel === null) {
+    record.baseline.kernelMix = readKernelMix(state);
+    record.baseline.preset = readKernelPreset(state) ?? record.baseline.preset ?? null;
+  }
+
+  // Apply noise hint
+  if (normalized.noise !== null) {
+    if (record.applied.noise === null) {
+      record.baseline.noise = readNoise(state);
+    }
+    if (record.applied.noise !== normalized.noise) {
+      updateNumericValue(state, "noise", normalized.noise);
+      record.applied.noise = normalized.noise;
+    }
+  } else if (record.applied.noise !== null) {
+    updateNumericValue(state, "noise", record.baseline.noise);
+    record.applied.noise = null;
+  }
+
+  // Apply damping hint
+  if (normalized.damping !== null) {
+    if (record.applied.damping === null) {
+      record.baseline.damping = readDamping(state);
+    }
+    if (record.applied.damping !== normalized.damping) {
+      updateNumericValue(state, "damping", clamp01(normalized.damping));
+      record.applied.damping = normalized.damping;
+    }
+  } else if (record.applied.damping !== null) {
+    updateNumericValue(state, "damping", record.baseline.damping);
+    record.applied.damping = null;
+  }
+
+  // Apply kernel hint
+  if (normalized.kernel) {
+    if (record.applied.kernel === null) {
+      record.baseline.kernelMix = readKernelMix(state);
+      record.baseline.preset = readKernelPreset(state) ?? record.baseline.preset ?? null;
+    }
+    if (record.applied.kernel !== normalized.kernel) {
+      applyKernelMapping(state, normalized.kernel, record.baseline);
+      record.applied.kernel = normalized.kernel;
+    }
+  } else if (record.applied.kernel !== null) {
+    updateNumericValue(state, "kernelMix", record.baseline.kernelMix);
+    updateStringValue(state, "kernel", record.baseline.preset ?? null);
+    record.applied.kernel = null;
+  }
+}

--- a/src/lib/physics/adapters.ts
+++ b/src/lib/physics/adapters.ts
@@ -1,0 +1,179 @@
+import { getRegistryEntry } from './registry';
+import { validateParams } from './validators';
+
+export interface EngineSuggestions {
+  readonly noise: number | null;
+  readonly threshold: number | null;
+  readonly kernel: string | null;
+  readonly gain: number | null;
+  readonly resolution: number | null;
+  readonly modulation: number | null;
+}
+
+export interface EngineAdapterResult {
+  readonly entryId: string;
+  readonly params: Record<string, number>;
+  readonly warnings: string[];
+  readonly suggestions: EngineSuggestions;
+}
+
+const BASE_SUGGESTIONS: EngineSuggestions = {
+  noise: null,
+  threshold: null,
+  kernel: null,
+  gain: null,
+  resolution: null,
+  modulation: null,
+};
+
+const hasFiniteValue = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const cloneBaseSuggestions = (): EngineSuggestions => ({ ...BASE_SUGGESTIONS });
+
+export const toEngine = (
+  entryId: string,
+  params: Record<string, unknown> = {},
+): EngineAdapterResult => {
+  const validation = validateParams(entryId, params);
+  const suggestions = cloneBaseSuggestions();
+  const resolvedEntry = getRegistryEntry(entryId);
+
+  switch (validation.entryId) {
+    case 'vacuum': {
+      const fluctuation = validation.params.fluctuationAmplitude;
+      const energyDensity = validation.params.energyDensity;
+      const correlationLength = validation.params.correlationLength;
+
+      if (hasFiniteValue(fluctuation)) {
+        suggestions.noise = fluctuation;
+        suggestions.modulation = Number((fluctuation * 0.25).toFixed(6));
+      }
+
+      if (hasFiniteValue(energyDensity)) {
+        suggestions.threshold = Number((energyDensity * 0.5).toPrecision(6));
+        suggestions.gain = Number((energyDensity * 1e12).toPrecision(6));
+      }
+
+      if (hasFiniteValue(correlationLength)) {
+        suggestions.kernel = 'gaussian';
+        suggestions.resolution = Number(correlationLength.toPrecision(6));
+      } else if (resolvedEntry) {
+        suggestions.kernel = 'gaussian';
+      }
+      break;
+    }
+    case 'tunneling': {
+      const barrierHeight = validation.params.barrierHeight;
+      const barrierWidth = validation.params.barrierWidth;
+      const temperature = validation.params.temperature;
+
+      if (hasFiniteValue(barrierHeight)) {
+        suggestions.threshold = Number(barrierHeight.toPrecision(6));
+        suggestions.gain = Number(Math.exp(-barrierHeight / 5).toPrecision(6));
+      }
+
+      if (hasFiniteValue(barrierWidth)) {
+        suggestions.resolution = Number(barrierWidth.toPrecision(6));
+      }
+
+      if (hasFiniteValue(temperature)) {
+        suggestions.noise = Number((1 / (temperature + 1)).toPrecision(6));
+        suggestions.modulation = Number((temperature * 0.1).toPrecision(6));
+      }
+
+      suggestions.kernel = 'exponential';
+      break;
+    }
+    case 'nuclear': {
+      const fusionRate = validation.params.fusionRate;
+      const confinementTime = validation.params.confinementTime;
+      const plasmaDensity = validation.params.plasmaDensity;
+
+      if (hasFiniteValue(fusionRate)) {
+        suggestions.noise = Number((1 / Math.sqrt(fusionRate + 1e-9)).toPrecision(6));
+        suggestions.gain = Number((fusionRate * 1e-6).toPrecision(6));
+      }
+
+      if (hasFiniteValue(confinementTime)) {
+        suggestions.resolution = Number((1 / (confinementTime + 1e-6)).toPrecision(6));
+        if (hasFiniteValue(fusionRate)) {
+          suggestions.modulation = Number(
+            (fusionRate * confinementTime * 1e-3).toPrecision(6),
+          );
+        }
+      }
+
+      if (hasFiniteValue(plasmaDensity)) {
+        suggestions.threshold = Number(plasmaDensity.toPrecision(6));
+      }
+
+      suggestions.kernel = 'lorentzian';
+      break;
+    }
+    case 'neutrino': {
+      const oscillationLength = validation.params.oscillationLength;
+      const massSplitting = validation.params.massSplitting;
+      const mixingAngle = validation.params.mixingAngle;
+
+      if (hasFiniteValue(oscillationLength)) {
+        suggestions.resolution = Number(oscillationLength.toPrecision(6));
+      }
+
+      if (hasFiniteValue(massSplitting)) {
+        suggestions.noise = Number(massSplitting.toPrecision(6));
+      }
+
+      if (hasFiniteValue(mixingAngle)) {
+        const radians = (mixingAngle * Math.PI) / 180;
+        suggestions.threshold = Number(mixingAngle.toPrecision(6));
+        suggestions.gain = Number(Math.sin(radians).toPrecision(6));
+        if (hasFiniteValue(oscillationLength)) {
+          suggestions.modulation = Number((massSplitting * oscillationLength).toPrecision(6));
+        }
+      }
+
+      suggestions.kernel = 'wave';
+      break;
+    }
+    case 'star-formation': {
+      const gasDensity = validation.params.gasDensity;
+      const turbulence = validation.params.turbulence;
+      const metallicity = validation.params.metallicity;
+
+      if (hasFiniteValue(gasDensity)) {
+        suggestions.threshold = Number(gasDensity.toPrecision(6));
+      }
+
+      if (hasFiniteValue(turbulence)) {
+        suggestions.noise = Number(turbulence.toPrecision(6));
+        if (hasFiniteValue(gasDensity) && turbulence !== 0) {
+          suggestions.resolution = Number((gasDensity / turbulence).toPrecision(6));
+        }
+      }
+
+      if (hasFiniteValue(metallicity)) {
+        suggestions.gain = Number(metallicity.toPrecision(6));
+        if (hasFiniteValue(turbulence)) {
+          suggestions.modulation = Number((metallicity * turbulence).toPrecision(6));
+        }
+      }
+
+      suggestions.kernel = 'adaptive';
+      break;
+    }
+    default: {
+      if (!resolvedEntry) {
+        suggestions.kernel = null;
+      }
+      break;
+    }
+  }
+
+  return {
+    entryId: validation.entryId,
+    params: validation.params,
+    warnings: validation.warnings,
+    suggestions,
+  };
+};

--- a/src/lib/physics/presets.ts
+++ b/src/lib/physics/presets.ts
@@ -1,0 +1,231 @@
+import { normalizeEntryId } from "./registry";
+
+export interface PhysicsPreset {
+  readonly id: string;
+  readonly entryId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly params: Record<string, number>;
+}
+
+interface PhysicsPresetDefinition {
+  readonly id: string;
+  readonly entryId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly params: Record<string, number>;
+}
+
+const definePreset = (definition: PhysicsPresetDefinition): PhysicsPreset => ({
+  ...definition,
+  entryId: normalizeEntryId(definition.entryId),
+});
+
+const PRESET_DEFINITIONS: readonly PhysicsPresetDefinition[] = [
+  {
+    id: "vacuum_lab_low",
+    entryId: "vacuum",
+    name: "Vacío de laboratorio (bajo ruido)",
+    description:
+      "Condiciones representativas de cámaras de vacío experimentales con fluctuaciones moderadas.",
+    params: {
+      energyDensity: 2e-10,
+      fluctuationAmplitude: 0.8,
+      correlationLength: 5e-13,
+    },
+  },
+  {
+    id: "vacuum_cosmic_baseline",
+    entryId: "vacuum",
+    name: "Vacío cósmico (basal)",
+    description:
+      "Configuración alineada con la densidad de energía promedio del vacío cosmológico.",
+    params: {
+      energyDensity: 5e-10,
+      fluctuationAmplitude: 1.5,
+      correlationLength: 2e-12,
+    },
+  },
+  {
+    id: "vacuum_high_fluctuation",
+    entryId: "vacuum",
+    name: "Vacío excitado (alta fluctuación)",
+    description:
+      "Escenario para analizar estados con amplitudes de fluctuación elevadas y correlación extendida.",
+    params: {
+      energyDensity: 8e-10,
+      fluctuationAmplitude: 9.5,
+      correlationLength: 8e-12,
+    },
+  },
+  {
+    id: "tunnel_electron_nm",
+    entryId: "tunneling",
+    name: "Túnel electrón (nanoestructura)",
+    description:
+      "Modelo para electrones atravesando barreras nanométricas a temperatura criogénica.",
+    params: {
+      barrierHeight: 0.25,
+      barrierWidth: 1,
+      temperature: 4,
+    },
+  },
+  {
+    id: "tunnel_superconductor_gap",
+    entryId: "tunneling",
+    name: "Brecha superconductora",
+    description:
+      "Ajustes para estudiar túnel a través de brechas superconductoras con barreras delgadas.",
+    params: {
+      barrierHeight: 1.4,
+      barrierWidth: 0.45,
+      temperature: 0.3,
+    },
+  },
+  {
+    id: "tunnel_quantum_dot",
+    entryId: "tunneling",
+    name: "Punto cuántico activo",
+    description:
+      "Parámetros típicos de tunelamiento en puntos cuánticos operando a temperatura intermedia.",
+    params: {
+      barrierHeight: 0.8,
+      barrierWidth: 2.5,
+      temperature: 25,
+    },
+  },
+  {
+    id: "fusion_tokamak_startup",
+    entryId: "nuclear",
+    name: "Tokamak (fase de arranque)",
+    description:
+      "Escenario para plasma confinado magnéticamente durante las primeras fases de ignición.",
+    params: {
+      fusionRate: 2e5,
+      confinementTime: 1.5,
+      plasmaDensity: 80,
+    },
+  },
+  {
+    id: "fusion_core_sunlike",
+    entryId: "nuclear",
+    name: "Núcleo estelar tipo solar",
+    description:
+      "Aproximación de condiciones centrales para estrellas semejantes al Sol.",
+    params: {
+      fusionRate: 4e26,
+      confinementTime: 0.2,
+      plasmaDensity: 150,
+    },
+  },
+  {
+    id: "fusion_inertial_pulse",
+    entryId: "nuclear",
+    name: "Pulso de confinamiento inercial",
+    description:
+      "Perfil para cápsulas de fusión con confinamiento por láser de corta duración.",
+    params: {
+      fusionRate: 5e8,
+      confinementTime: 5e-4,
+      plasmaDensity: 520,
+    },
+  },
+  {
+    id: "neutrino_solar_baseline",
+    entryId: "neutrino",
+    name: "Oscilaciones solares",
+    description:
+      "Parámetros estándar para el análisis de neutrinos provenientes del Sol.",
+    params: {
+      oscillationLength: 1.496e5,
+      massSplitting: 7.4e-5,
+      mixingAngle: 33,
+    },
+  },
+  {
+    id: "neutrino_reactor_short",
+    entryId: "neutrino",
+    name: "Reactor (corto alcance)",
+    description:
+      "Condiciones para experimentos de neutrinos de reactor a baselines cortos.",
+    params: {
+      oscillationLength: 1.5,
+      massSplitting: 2.4e-3,
+      mixingAngle: 8.5,
+    },
+  },
+  {
+    id: "neutrino_atmospheric_long",
+    entryId: "neutrino",
+    name: "Atmosféricos (larga distancia)",
+    description:
+      "Configuración para trayectorias largas en oscilaciones atmosféricas.",
+    params: {
+      oscillationLength: 1e3,
+      massSplitting: 2.5e-3,
+      mixingAngle: 45,
+    },
+  },
+  {
+    id: "starcloud_quiescent",
+    entryId: "star-formation",
+    name: "Nube molecular tranquila",
+    description:
+      "Parámetros para regiones con formación estelar débil y turbulencia reducida.",
+    params: {
+      gasDensity: 5e-21,
+      turbulence: 5,
+      metallicity: 0.015,
+    },
+  },
+  {
+    id: "starburst_dwarf",
+    entryId: "star-formation",
+    name: "Brotes estelares en enanas",
+    description:
+      "Modelo para galaxias enanas con episodios intensos de formación estelar.",
+    params: {
+      gasDensity: 8e-20,
+      turbulence: 20,
+      metallicity: 0.005,
+    },
+  },
+  {
+    id: "giant_molecular_core",
+    entryId: "star-formation",
+    name: "Núcleo molecular gigante",
+    description:
+      "Condiciones densas típicas de núcleos masivos en vías de colapso.",
+    params: {
+      gasDensity: 2e-19,
+      turbulence: 12,
+      metallicity: 0.03,
+    },
+  },
+] as const;
+
+const presetsByEntry: Record<string, PhysicsPreset[]> = {};
+const presetIndex: Record<string, PhysicsPreset> = {};
+
+PRESET_DEFINITIONS.forEach((definition) => {
+  const preset = definePreset(definition);
+  if (!presetsByEntry[preset.entryId]) {
+    presetsByEntry[preset.entryId] = [];
+  }
+  presetsByEntry[preset.entryId].push(preset);
+  presetIndex[preset.id] = preset;
+});
+
+Object.values(presetsByEntry).forEach((presets) => {
+  presets.sort((a, b) => a.name.localeCompare(b.name, "es"));
+});
+
+export const PHYSICS_PRESETS: Record<string, readonly PhysicsPreset[]> = presetsByEntry;
+
+export const getPresetsForEntry = (entryId: string): readonly PhysicsPreset[] => {
+  const normalized = normalizeEntryId(entryId);
+  return PHYSICS_PRESETS[normalized] ?? [];
+};
+
+export const getPresetById = (presetId: string): PhysicsPreset | undefined =>
+  presetIndex[presetId];

--- a/src/lib/physics/registry.ts
+++ b/src/lib/physics/registry.ts
@@ -1,0 +1,176 @@
+export interface ConstraintDefinition {
+  readonly min?: number;
+  readonly max?: number;
+  readonly integer?: boolean;
+  readonly step?: number;
+}
+
+export interface PhysicsParameterDefinition {
+  readonly label: string;
+  readonly description: string;
+  readonly unit: string | null;
+  readonly default: number;
+  readonly constraints: ConstraintDefinition;
+}
+
+export interface PhysicsRegistryEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly inputs: Record<string, PhysicsParameterDefinition>;
+}
+
+export const normalizeEntryId = (entryId: string): string =>
+  entryId.trim().toLowerCase().replace(/\s+/g, '-');
+
+export const PHYSICS_REGISTRY: Record<string, PhysicsRegistryEntry> = {
+  vacuum: {
+    id: 'vacuum',
+    name: 'Quantum Vacuum',
+    description: 'Baseline configuration for vacuum fluctuation simulations.',
+    inputs: {
+      energyDensity: {
+        label: 'Energy Density',
+        description: 'Energy density of the vacuum state.',
+        unit: 'J/m^3',
+        default: 5e-10,
+        constraints: { min: 0 },
+      },
+      fluctuationAmplitude: {
+        label: 'Fluctuation Amplitude',
+        description: 'Relative amplitude of vacuum fluctuations.',
+        unit: 'dimensionless',
+        default: 1,
+        constraints: { min: 0, max: 20 },
+      },
+      correlationLength: {
+        label: 'Correlation Length',
+        description: 'Characteristic correlation length for fluctuations.',
+        unit: 'm',
+        default: 1e-12,
+        constraints: { min: 0 },
+      },
+    },
+  },
+  tunneling: {
+    id: 'tunneling',
+    name: 'Quantum Tunneling',
+    description: 'Parameters describing particle tunneling through a barrier.',
+    inputs: {
+      barrierHeight: {
+        label: 'Barrier Height',
+        description: 'Potential barrier height for tunneling calculations.',
+        unit: 'eV',
+        default: 0.5,
+        constraints: { min: 0 },
+      },
+      barrierWidth: {
+        label: 'Barrier Width',
+        description: 'Spatial width of the potential barrier.',
+        unit: 'nm',
+        default: 0.3,
+        constraints: { min: 0, max: 10 },
+      },
+      temperature: {
+        label: 'Temperature',
+        description: 'Ambient temperature influencing tunneling probability.',
+        unit: 'K',
+        default: 2,
+        constraints: { min: 0 },
+      },
+    },
+  },
+  nuclear: {
+    id: 'nuclear',
+    name: 'Nuclear Fusion',
+    description: 'Parameter space for nuclear fusion confinement studies.',
+    inputs: {
+      fusionRate: {
+        label: 'Fusion Rate',
+        description: 'Expected particle fusion events per second.',
+        unit: '1/s',
+        default: 1e6,
+        constraints: { min: 0 },
+      },
+      confinementTime: {
+        label: 'Confinement Time',
+        description: 'Average particle confinement time.',
+        unit: 's',
+        default: 5,
+        constraints: { min: 0 },
+      },
+      plasmaDensity: {
+        label: 'Plasma Density',
+        description: 'Mass density of the plasma.',
+        unit: 'kg/m^3',
+        default: 120,
+        constraints: { min: 0 },
+      },
+    },
+  },
+  neutrino: {
+    id: 'neutrino',
+    name: 'Neutrino Oscillations',
+    description: 'Parameters for neutrino flavor oscillation models.',
+    inputs: {
+      oscillationLength: {
+        label: 'Oscillation Length',
+        description: 'Characteristic oscillation length.',
+        unit: 'km',
+        default: 500,
+        constraints: { min: 1 },
+      },
+      massSplitting: {
+        label: 'Mass Splitting',
+        description: 'Squared mass difference between neutrino states.',
+        unit: 'eV^2',
+        default: 7.5e-5,
+        constraints: { min: 0 },
+      },
+      mixingAngle: {
+        label: 'Mixing Angle',
+        description: 'Flavor mixing angle.',
+        unit: 'deg',
+        default: 33,
+        constraints: { min: 0, max: 90, step: 0.1 },
+      },
+    },
+  },
+  'star-formation': {
+    id: 'star-formation',
+    name: 'Star Formation',
+    description: 'Macroscopic parameters driving star formation rates.',
+    inputs: {
+      gasDensity: {
+        label: 'Gas Density',
+        description: 'Density of the star-forming gas cloud.',
+        unit: 'kg/m^3',
+        default: 1e-20,
+        constraints: { min: 0 },
+      },
+      turbulence: {
+        label: 'Turbulence Velocity',
+        description: 'Velocity dispersion within the gas.',
+        unit: 'km/s',
+        default: 10,
+        constraints: { min: 0 },
+      },
+      metallicity: {
+        label: 'Metallicity',
+        description: 'Relative metallicity compared to solar.',
+        unit: 'Z/Zsun',
+        default: 0.02,
+        constraints: { min: 0, max: 1 },
+      },
+    },
+  },
+};
+
+export const getRegistryEntry = (
+  entryId: string,
+): PhysicsRegistryEntry | undefined => {
+  const normalized = normalizeEntryId(entryId);
+  return PHYSICS_REGISTRY[normalized];
+};
+
+export type PhysicsRegistry = typeof PHYSICS_REGISTRY;

--- a/src/lib/physics/validators.ts
+++ b/src/lib/physics/validators.ts
@@ -1,0 +1,117 @@
+import {
+  getRegistryEntry,
+  normalizeEntryId,
+  PHYSICS_REGISTRY,
+  PhysicsParameterDefinition,
+} from './registry';
+
+export interface ValidationResult {
+  readonly entryId: string;
+  readonly params: Record<string, number>;
+  readonly warnings: string[];
+}
+
+const clamp = (value: number, min?: number, max?: number): number => {
+  let result = value;
+  if (typeof min === 'number' && result < min) {
+    result = min;
+  }
+  if (typeof max === 'number' && result > max) {
+    result = max;
+  }
+  return result;
+};
+
+const enforceStep = (value: number, step?: number): number => {
+  if (!step || step <= 0) {
+    return value;
+  }
+  const stepped = Math.round(value / step) * step;
+  return Number(stepped.toPrecision(12));
+};
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const sanitizeValue = (
+  key: string,
+  incoming: unknown,
+  definition: PhysicsParameterDefinition,
+  warnings: string[],
+): number => {
+  const { default: fallback, constraints } = definition;
+  if (!isFiniteNumber(incoming)) {
+    warnings.push(`Parameter "${key}" is invalid; defaulting to ${fallback}.`);
+    return fallback;
+  }
+
+  let value = incoming;
+
+  if (constraints.integer) {
+    const rounded = Math.round(value);
+    if (rounded !== value) {
+      warnings.push(`Parameter "${key}" rounded to nearest integer (${rounded}).`);
+    }
+    value = rounded;
+  }
+
+  const stepped = enforceStep(value, constraints.step);
+  if (stepped !== value) {
+    warnings.push(`Parameter "${key}" adjusted to respect step of ${constraints.step}.`);
+    value = stepped;
+  }
+
+  const clamped = clamp(value, constraints.min, constraints.max);
+  if (clamped !== value) {
+    const range = `${
+      typeof constraints.min === 'number' ? constraints.min : '-∞'
+    } to ${typeof constraints.max === 'number' ? constraints.max : '∞'}`;
+    warnings.push(`Parameter "${key}" clamped to range ${range}.`);
+    value = clamped;
+  }
+
+  if (!Number.isFinite(value)) {
+    warnings.push(`Parameter "${key}" resolved to a non-finite value; resetting to default.`);
+    return fallback;
+  }
+
+  return value;
+};
+
+export const validateParams = (
+  entryId: string,
+  params: Record<string, unknown> = {},
+): ValidationResult => {
+  const normalizedId = normalizeEntryId(entryId);
+  const entry = getRegistryEntry(entryId);
+
+  if (!entry) {
+    return {
+      entryId: normalizedId,
+      params: {},
+      warnings: [`Unknown physics registry entry: ${entryId}.`],
+    };
+  }
+
+  const sanitized: Record<string, number> = {};
+  const warnings: string[] = [];
+
+  Object.entries(entry.inputs).forEach(([key, definition]) => {
+    const value = sanitizeValue(key, params?.[key], definition, warnings);
+    sanitized[key] = value;
+  });
+
+  Object.keys(params ?? {}).forEach((key) => {
+    if (!(key in entry.inputs)) {
+      warnings.push(`Parameter "${key}" is not defined for entry ${entry.id}.`);
+    }
+  });
+
+  return {
+    entryId: entry.id,
+    params: sanitized,
+    warnings,
+  };
+};
+
+export type RegistryParameterId = keyof typeof PHYSICS_REGISTRY;

--- a/src/ui/ExperimentsPanel.tsx
+++ b/src/ui/ExperimentsPanel.tsx
@@ -86,7 +86,7 @@ export function ExperimentsPanel({ onOpenDoc }: ExperimentsPanelProps) {
           onClick={onOpenDoc}
           type="button"
         >
-          Abrir en GitHub
+          Axiomas
         </button>
       </div>
     </section>

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -9,8 +9,10 @@ type HeaderProps = {
   onExportCapture: () => void;
   onToggleExperiments: () => void;
   onToggleMetrics: () => void;
+  onToggleParams: () => void;
   experimentsOpen: boolean;
   metricsOpen: boolean;
+  paramsOpen: boolean;
 };
 
 export function Header({
@@ -22,8 +24,10 @@ export function Header({
   onExportCapture,
   onToggleExperiments,
   onToggleMetrics,
+  onToggleParams,
   experimentsOpen,
   metricsOpen,
+  paramsOpen,
 }: HeaderProps) {
   const toggleButtonClassName = (isActive: boolean) =>
     isActive
@@ -59,6 +63,14 @@ export function Header({
           type="button"
         >
           {metricsOpen ? "Cerrar métricas" : "Métricas básicas"}
+        </button>
+        <button
+          className={toggleButtonClassName(paramsOpen)}
+          onClick={onToggleParams}
+          aria-pressed={paramsOpen}
+          type="button"
+        >
+          {paramsOpen ? "Cerrar Φ–𝓛" : "Panel Φ–𝓛"}
         </button>
         <button
           className={toggleButtonClassName(experimentsOpen)}

--- a/src/ui/ParamsPanel.tsx
+++ b/src/ui/ParamsPanel.tsx
@@ -224,8 +224,9 @@ export function ParamsPanel({ onApplySuggestions, lastAppliedResult }: ParamsPan
   };
 
   const handleApply = () => {
-    const baseParams = validationResult?.params ?? buildPayload();
-    const result = toEngine(selectedEntry.id, baseParams);
+    const rawParams = buildPayload();
+    const validation = validateParams(selectedEntry.id, rawParams);
+    const result = toEngine(validation.entryId, validation.params);
     setValidationResult({
       entryId: result.entryId,
       params: result.params,

--- a/src/ui/ParamsPanel.tsx
+++ b/src/ui/ParamsPanel.tsx
@@ -1,0 +1,287 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  PHYSICS_REGISTRY,
+  getRegistryEntry,
+  type ConstraintDefinition,
+  type PhysicsRegistryEntry,
+} from "../lib/physics/registry";
+import { validateParams, type ValidationResult } from "../lib/physics/validators";
+import { toEngine, type EngineAdapterResult } from "../lib/physics/adapters";
+
+type ParamsPanelProps = {
+  onApplySuggestions: (result: EngineAdapterResult) => void;
+  lastAppliedResult: EngineAdapterResult | null;
+};
+
+type ParamInputs = Record<string, string>;
+
+const formatConstraintNumber = (value: number | undefined): string => {
+  if (value === undefined) {
+    return "N/D";
+  }
+  return Number.isInteger(value) ? value.toString() : value.toPrecision(6);
+};
+
+const formatBoolean = (value: boolean | undefined): string => {
+  if (value === undefined) {
+    return "N/D";
+  }
+  return value ? "Sí" : "No";
+};
+
+const formatSuggestionValue = (value: number | string | null): string => {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value.toString() : value.toPrecision(6);
+  }
+  return value;
+};
+
+const buildDefaultInputs = (entry: PhysicsRegistryEntry): ParamInputs => {
+  const defaults: ParamInputs = {};
+  Object.entries(entry.inputs).forEach(([key, definition]) => {
+    defaults[key] = definition.default.toString();
+  });
+  return defaults;
+};
+
+const sanitizeInputsFromResult = (entry: PhysicsRegistryEntry, result: ValidationResult): ParamInputs => {
+  const sanitized: ParamInputs = {};
+  Object.keys(entry.inputs).forEach((key) => {
+    const value = result.params[key];
+    sanitized[key] = value != null ? value.toString() : "";
+  });
+  return sanitized;
+};
+
+export function ParamsPanel({ onApplySuggestions, lastAppliedResult }: ParamsPanelProps) {
+  const registryEntries = useMemo(() => Object.values(PHYSICS_REGISTRY), []);
+  const [selectedEntryId, setSelectedEntryId] = useState(() => registryEntries[0]?.id ?? "");
+  const selectedEntry = useMemo(() => {
+    if (!selectedEntryId) {
+      return registryEntries[0];
+    }
+    return getRegistryEntry(selectedEntryId) ?? registryEntries[0];
+  }, [registryEntries, selectedEntryId]);
+
+  const [paramValues, setParamValues] = useState<ParamInputs>(() =>
+    selectedEntry ? buildDefaultInputs(selectedEntry) : {},
+  );
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!selectedEntry) {
+      return;
+    }
+    setParamValues(buildDefaultInputs(selectedEntry));
+    setValidationResult(null);
+    setWarnings([]);
+  }, [selectedEntry]);
+
+  if (!selectedEntry) {
+    return null;
+  }
+
+  const buildPayload = (): Record<string, unknown> => {
+    const payload: Record<string, unknown> = {};
+    Object.entries(paramValues).forEach(([key, value]) => {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        payload[key] = undefined;
+        return;
+      }
+      const numeric = Number(trimmed);
+      payload[key] = Number.isFinite(numeric) ? numeric : trimmed;
+    });
+    return payload;
+  };
+
+  const handleValidate = () => {
+    const raw = buildPayload();
+    const result = validateParams(selectedEntry.id, raw);
+    setValidationResult(result);
+    setWarnings(result.warnings);
+    setParamValues(sanitizeInputsFromResult(selectedEntry, result));
+  };
+
+  const handleApply = () => {
+    const baseParams = validationResult?.params ?? buildPayload();
+    const result = toEngine(selectedEntry.id, baseParams);
+    setValidationResult({
+      entryId: result.entryId,
+      params: result.params,
+      warnings: result.warnings,
+    });
+    setWarnings(result.warnings);
+    const sanitizedParams = sanitizeInputsFromResult(selectedEntry, {
+      entryId: result.entryId,
+      params: result.params,
+      warnings: result.warnings,
+    });
+    setParamValues(sanitizedParams);
+    onApplySuggestions(result);
+  };
+
+  const renderConstraintDetails = (constraints: ConstraintDefinition) => (
+    <dl className="grid grid-cols-2 gap-3 text-xs text-slate-300 mt-2">
+      <div>
+        <dt className="uppercase tracking-wide text-slate-500">Mínimo</dt>
+        <dd className="text-slate-200">{formatConstraintNumber(constraints.min)}</dd>
+      </div>
+      <div>
+        <dt className="uppercase tracking-wide text-slate-500">Máximo</dt>
+        <dd className="text-slate-200">{formatConstraintNumber(constraints.max)}</dd>
+      </div>
+      <div>
+        <dt className="uppercase tracking-wide text-slate-500">Step</dt>
+        <dd className="text-slate-200">{formatConstraintNumber(constraints.step)}</dd>
+      </div>
+      <div>
+        <dt className="uppercase tracking-wide text-slate-500">Entero</dt>
+        <dd className="text-slate-200">{formatBoolean(constraints.integer)}</dd>
+      </div>
+    </dl>
+  );
+
+  return (
+    <section className="bg-slate-900/80 border border-slate-800 rounded-2xl p-4 space-y-5">
+      <header className="space-y-2">
+        <h2 className="text-lg font-semibold">Panel Φ–𝓛 (parámetros)</h2>
+        <p className="text-sm text-slate-400">
+          Selecciona un suceso Φ y ajusta sus parámetros antes de validar contra las limitantes 𝓛.
+        </p>
+        <div>
+          <label htmlFor="phi-entry" className="text-sm font-medium text-slate-200">
+            Suceso Φ
+          </label>
+          <select
+            id="phi-entry"
+            className="mt-1 w-full bg-slate-950/60 border border-slate-800 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            value={selectedEntry.id}
+            onChange={(event) => setSelectedEntryId(event.target.value)}
+          >
+            {registryEntries.map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-slate-400 mt-2">{selectedEntry.description}</p>
+        </div>
+      </header>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-slate-300">Parámetros Φ</h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {Object.entries(selectedEntry.inputs).map(([paramId, definition]) => {
+            const inputId = `${selectedEntry.id}-${paramId}`;
+            const min = definition.constraints.min;
+            const max = definition.constraints.max;
+            const step = definition.constraints.step ?? (definition.constraints.integer ? 1 : undefined);
+            return (
+              <div
+                key={paramId}
+                className="bg-slate-900/60 border border-slate-800/60 rounded-xl p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <label htmlFor={inputId} className="text-sm font-medium text-slate-200">
+                    {definition.label}
+                  </label>
+                  <span className="text-xs text-slate-400">
+                    {definition.unit ?? "sin unidad"}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-400">{definition.description}</p>
+                <input
+                  id={inputId}
+                  type="number"
+                  inputMode="decimal"
+                  value={paramValues[paramId] ?? ""}
+                  onChange={(event) =>
+                    setParamValues((prev) => ({ ...prev, [paramId]: event.target.value }))
+                  }
+                  min={min !== undefined ? min : undefined}
+                  max={max !== undefined ? max : undefined}
+                  step={step !== undefined ? step : "any"}
+                  className="w-full bg-slate-950/40 border border-slate-800 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-slate-300">Limitantes (𝓛)</h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {Object.entries(selectedEntry.inputs).map(([paramId, definition]) => (
+            <div
+              key={`${paramId}-constraints`}
+              className="bg-slate-900/50 border border-slate-800/40 rounded-xl p-3"
+            >
+              <div className="text-sm font-medium text-slate-200">{definition.label}</div>
+              {renderConstraintDetails(definition.constraints)}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-slate-300">Validación</h3>
+        {warnings.length === 0 ? (
+          <p className="text-xs text-slate-400">Sin advertencias. Usa “Validar” para comprobar límites.</p>
+        ) : (
+          <ul className="space-y-1 text-xs text-amber-300">
+            {warnings.map((warning, index) => (
+              <li key={`${warning}-${index}`} className="bg-amber-500/10 border border-amber-500/40 rounded-lg px-3 py-2">
+                {warning}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <button
+          type="button"
+          className="px-3 py-1.5 rounded-xl bg-slate-800 hover:bg-slate-700 text-sm"
+          onClick={handleValidate}
+        >
+          Validar
+        </button>
+        <button
+          type="button"
+          className="px-3 py-1.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-sm"
+          onClick={handleApply}
+        >
+          Aplicar al simulador (sugerencias)
+        </button>
+      </div>
+
+      {lastAppliedResult && (
+        <section className="space-y-3">
+          <header className="space-y-1">
+            <h3 className="text-sm font-semibold text-slate-300">Sugerencias guardadas</h3>
+            <p className="text-xs text-slate-400">
+              Última aplicación para <span className="text-slate-200">{lastAppliedResult.entryId}</span>.
+            </p>
+          </header>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {Object.entries(lastAppliedResult.suggestions).map(([key, value]) => (
+              <div
+                key={key}
+                className="bg-slate-900/50 border border-slate-800/50 rounded-xl px-3 py-2"
+              >
+                <div className="text-xs uppercase tracking-wide text-slate-500">{key}</div>
+                <div className="text-base text-slate-100">{formatSuggestionValue(value)}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}

--- a/tests/config.test.mts
+++ b/tests/config.test.mts
@@ -1,0 +1,75 @@
+import {
+  DEFAULT_EXPERIMENTS_DOC_URL,
+  getExperimentsDocUrl,
+} from "../src/config.js";
+
+type MaybeString = string | null | undefined;
+
+function setRuntimeUrl(url: MaybeString): void {
+  const globalRef = globalThis as any;
+  if (url === undefined) {
+    delete globalRef.window;
+    return;
+  }
+  globalRef.window = {
+    __BB_RUNTIME_CONFIG__: {
+      experimentsDocUrl: url ?? undefined,
+    },
+  };
+}
+
+function setViteEnv(url: MaybeString): void {
+  const globalRef = globalThis as any;
+  if (url === undefined) {
+    delete globalRef.__BB_IMPORT_META_ENV__;
+    return;
+  }
+  globalRef.__BB_IMPORT_META_ENV__ = {
+    VITE_EXPERIMENTS_DOC_URL: url ?? undefined,
+  };
+}
+
+function resetEnvironment(): void {
+  setRuntimeUrl(undefined);
+  setViteEnv(undefined);
+}
+
+function runTest(name: string, fn: () => void): void {
+  try {
+    resetEnvironment();
+    fn();
+    console.log(`\u2714\ufe0f  ${name}`);
+  } catch (error) {
+    console.error(`\u274c  ${name}`);
+    throw error;
+  } finally {
+    resetEnvironment();
+  }
+}
+
+function expectEqual(actual: unknown, expected: unknown, message?: string): void {
+  if (actual !== expected) {
+    const error = new Error(
+      message ?? `Expected ${String(actual)} to strictly equal ${String(expected)}`
+    );
+    (error as Error & { actual?: unknown }).actual = actual;
+    (error as Error & { expected?: unknown }).expected = expected;
+    throw error;
+  }
+}
+
+runTest("prefers runtime override over Vite environment", () => {
+  setRuntimeUrl("https://runtime.example/docs");
+  setViteEnv("https://vite.example/docs");
+  expectEqual(getExperimentsDocUrl(), "https://runtime.example/docs");
+});
+
+runTest("falls back to Vite value when runtime is empty", () => {
+  setRuntimeUrl("");
+  setViteEnv("https://vite.example/docs");
+  expectEqual(getExperimentsDocUrl(), "https://vite.example/docs");
+});
+
+runTest("falls back to default when neither source provides a value", () => {
+  expectEqual(getExperimentsDocUrl(), DEFAULT_EXPERIMENTS_DOC_URL);
+});

--- a/tests/config.test.mts
+++ b/tests/config.test.mts
@@ -73,3 +73,14 @@ runTest("falls back to Vite value when runtime is empty", () => {
 runTest("falls back to default when neither source provides a value", () => {
   expectEqual(getExperimentsDocUrl(), DEFAULT_EXPERIMENTS_DOC_URL);
 });
+
+runTest("ignores relative runtime overrides", () => {
+  setRuntimeUrl("/relative/path.pdf");
+  expectEqual(getExperimentsDocUrl(), DEFAULT_EXPERIMENTS_DOC_URL);
+});
+
+runTest("ignores non-http Vite values", () => {
+  setRuntimeUrl(null);
+  setViteEnv("ftp://example.com/file.pdf");
+  expectEqual(getExperimentsDocUrl(), DEFAULT_EXPERIMENTS_DOC_URL);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": ".tmp-tests",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [],
+    "target": "ES2020"
+  },
+  "include": ["src/config.ts", "tests/**/*.mts"]
+}


### PR DESCRIPTION
## Summary
- add a physics registry for vacuum, tunneling, nuclear, neutrino, and star-formation scenarios
- implement parameter validation that auto-corrects constraint violations and records warnings
- expose engine adapter helpers that produce stable suggestion objects for each registry entry

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cae2b976808320a98b0d42e5fb396d